### PR TITLE
Remove redundant ns placement cleanup

### DIFF
--- a/README-cdk.md
+++ b/README-cdk.md
@@ -506,7 +506,6 @@ To clean up only the test application run:
 
 ~~~sh
 oc delete ns test-namespace
-oc delete federatednamespaceplacement test-namespace
 ~~~
 
 This leaves the two clusters with federation deployed. If you want to remove everything run:

--- a/README-minishift.md
+++ b/README-minishift.md
@@ -481,7 +481,6 @@ To clean up only the test application run:
 
 ~~~sh
 oc delete ns test-namespace
-oc delete federatednamespaceplacement test-namespace
 ~~~
 
 This leaves the two clusters with federation deployed. If you want to remove everything run:


### PR DESCRIPTION
The placement object is inside the test namespace and it should be cascade-deleted when the ns is deleted.
