### PR TITLE
Removed federation-v2 submodule and updated instructions to work with kubefed v0.0.10

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "federation-v2"]
-	path = federation-v2
-	url = https://github.com/kubernetes-sigs/federation-v2

--- a/README-cdk.md
+++ b/README-cdk.md
@@ -2,34 +2,32 @@
 
 <!-- TOC depthFrom:1 insertAnchor:true orderedList:true -->
 
-1. [Introduction](#introduction)
-2. [Pre-requisites](#pre-requisites)
-    1. [Install the CDK](#install-the-cdk)
-        1. [Configure and validate the CDK](#configure-and-validate-the-cdk)
-    2. [Install the kubefed2 binary](#install-the-kubefed2-binary)
-    3. [Download the example code](#download-the-example-code)
-3. [Federation deployment](#federation-deployment)
-    1. [Create the two OpenShift clusters](#create-the-two-openshift-clusters)
-        1. [Configure client context for cluster admin access](#configure-client-context-for-cluster-admin-access)
-    2. [Deploy Federation](#deploy-federation)
-    3. [Register the clusters in the cluster registry](#register-the-clusters-in-the-cluster-registry)
-4. [Example application](#example-application)
-    1. [Create a federated namespace](#create-a-federated-namespace)
-    2. [Deploy the application](#deploy-the-application)
-    3. [Verify that the application is running](#verify-that-the-application-is-running)
-    4. [Modify placement](#modify-placement)
-5. [Clean up](#clean-up)
-6. [What’s next?](#whats-next)
-7. [Known Issues](#known-issues)
+- [Introduction](#introduction)
+- [Pre-requisites](#pre-requisites)
+  - [Install the CDK](#install-the-cdk)
+    - [Configure and validate the CDK](#configure-and-validate-the-cdk)
+  - [Install the kubefedctl binary](#install-the-kubefedctl-binary)
+  - [Download the example code](#download-the-example-code)
+- [Federation deployment](#federation-deployment)
+  - [Create the two OpenShift clusters](#create-the-two-openshift-clusters)
+    - [Configure client context for cluster admin access](#configure-client-context-for-cluster-admin-access)
+  - [Deploy Federation](#deploy-federation)
+  - [Register the clusters](#register-the-clusters)
+- [Example application](#example-application)
+  - [Deploy the application](#deploy-the-application)
+  - [Verify that the application is running](#verify-that-the-application-is-running)
+  - [Modify placement](#modify-placement)
+- [Clean up](#clean-up)
+- [What’s next?](#whats-next)
+- [Known Issues](#known-issues)
 
 <!-- /TOC -->
 
 <a id="markdown-introduction" name="introduction"></a>
 # Introduction
 
-This demo is a simple deployment of [Kubernetes Federation v2](https://github.com/kubernetes-sigs/federation-v2) on two OpenShift
-clusters. A sample application is deployed to both clusters through the
-federation controller.
+This demo is a simple deployment of [Federation Operator](https://operatorhub.io/operator/alpha/federation.v0.0.10) on two OpenShift
+clusters. A sample application is deployed to both clusters through the Federation controller.
 
 <a id="markdown-pre-requisites" name="pre-requisites"></a>
 # Pre-requisites
@@ -94,25 +92,25 @@ read -s -p 'Password: ' MINISHIFT_PASSWORD
 export MINISHIFT_PASSWORD
 ~~~
 
-<a id="markdown-install-the-kubefed2-binary" name="install-the-kubefed2-binary"></a>
-## Install the kubefed2 binary
+<a id="markdown-install-the-kubefedctl-binary" name="install-the-kubefedctl-binary"></a>
+## Install the kubefedctl binary
 
-The `kubefed2` tool manages federated cluter registration. Download the
-0.0.7 release and unpack it into a diretory in your PATH (the
+The `kubefedctl` tool manages federated cluster registration. Download the
+v0.0.10 release and unpack it into a directory in your PATH (the
 example uses `$HOME/bin`):
 
 ~~~sh
-curl -LOs https://github.com/kubernetes-sigs/federation-v2/releases/download/v0.0.7/kubefed2.tar.gz
-tar xzf kubefed2.tar.gz -C ~/bin
-rm -f kubefed2.tar.gz
+curl -LOs https://github.com/kubernetes-sigs/kubefed/releases/download/v0.0.10/kubefedctl.tgz
+tar xzf kubefedctl.tgz -C ~/bin
+rm -f kubefedctl.tgz
 ~~~
 
-Verify that `kubefed2` is working:
+Verify that `kubefedctl` is working:
 
 ~~~sh
-kubefed2 version
+kubefedctl version
 
-kubefed2 version: version.Info{Version:"v0.0.7", GitCommit:"83b778b6d92a7929efb7687d3d3d64bf0b3ad3bc", GitTreeState:"clean", BuildDate:"2019-03-19T18:40:46Z", GoVersion:"go1.11.2", Compiler:"gc", Platform:"linux/amd64"}
+kubefedctl version: version.Info{Version:"v0.0.10-dirty", GitCommit:"71d233ede685707df554ef653e06bf7f0229415c", GitTreeState:"dirty", BuildDate:"2019-05-06T22:30:31Z", GoVersion:"go1.11.2", Compiler:"gc", Platform:"linux/amd64"}
 ~~~
 
 <a id="markdown-download-the-example-code" name="download-the-example-code"></a>
@@ -121,7 +119,7 @@ kubefed2 version: version.Info{Version:"v0.0.7", GitCommit:"83b778b6d92a7929efb7
 Clone the demo code to your local machine:
 
 ~~~sh
-git clone --recurse-submodules https://github.com/openshift/federation-dev.git
+git clone https://github.com/openshift/federation-dev.git
 cd federation-dev/
 ~~~
 
@@ -175,7 +173,7 @@ your `$PATH`:
 eval $(cdk oc-env)
 ~~~
 
-Cluster-wide federation needs cluster administrator privileges, so switch the
+We need cluster administrator privileges, so switch the
 `oc` client contexts to use the `system:admin` account instead of the default
 unprivileged `developer` user:
 
@@ -206,7 +204,7 @@ cluster1
 system:admin
 ~~~
 
-The presence and naming of the client contexts is important because the `kubefed2` tool uses them to manage cluster registration, and they are referenced by context name.
+The presence and naming of the client contexts is important because the `kubefedctl` tool uses them to manage cluster registration, and they are referenced by context name.
 
 <a id="markdown-deploy-federation" name="deploy-federation"></a>
 ## Deploy Federation
@@ -215,126 +213,115 @@ Federation target clusters do not require federation to be installed on them at
 all, but for convenience we will use one of the clusters (`cluster1`) to host
 the federation control plane.
 
-The federation controller also needs elevated privileges. Grant cluster-admin
-level to the default service account of the federation-system project (the
-project itself will be created soon):
+At the moment, the Federation Operator only works in namespace-scoped mode, in the future cluster-scoped mode will be supported as well by the operator.
+
+In order to deploy the operator, we are going to use `OLM`, so we will need to deploy `OLM` before deploying the federation operator.
 
 ~~~sh
-oc create clusterrolebinding federation-admin \
-          --clusterrole="cluster-admin" \
-          --serviceaccount="federation-system:default"
+oc create -f olm/01-olm.yaml
+oc create -f olm/02-olm.yaml
 ~~~
 
-Change directory to Federation V2 repo (The repository submodule is already pointing to `tag/v0.0.7`):
+Now that we have the `OLM` deployed, it is time to deploy the federation operator. We will create a new namespace `test-namespace` where the kubefed controller will be deployed.
+
+Wait until all pods in namespace `olm` are running:
 
 ~~~sh
-cd federation-v2/
+oc get pods -n olm
+
+NAME                               READY     STATUS    RESTARTS   AGE
+catalog-operator-bfc6fd7bc-xdwbs   1/1       Running   0          3m
+olm-operator-787885c577-wmzxp      1/1       Running   0          3m
+olm-operators-gmnk4                1/1       Running   0          3m
+operatorhubio-catalog-gng4x        1/1       Running   0          3m
+packageserver-7fc659d9cb-5qbw9     1/1       Running   0          2m
+packageserver-7fc659d9cb-tl9gv     1/1       Running   0          2m
 ~~~
 
-Create the required namespaces:
+Then, create the kubefed subscription.
 
 ~~~sh
-oc create ns federation-system
-oc create ns kube-multicluster-public
+oc create -f olm/kubefed.yaml
 ~~~
 
-Deploy the federation control plane and its associated Custom Resource Definitions ([CRDs](https://kubernetes.io/docs/concepts/extend-kubernetes/api-extension/custom-resources/)):
+After a short while the kubefed controller manager pod is running:
+
+> **NOTE:** It can take up to a minute for the pod to appear
 
 ~~~sh
-sed -i "s/federation-v2:latest/federation-v2:v0.0.7/g" hack/install-latest.yaml
-oc -n federation-system apply --validate=false -f hack/install-latest.yaml
+oc get pod -n test-namespace
+
+NAME                              READY     STATUS    RESTARTS   AGE
+federation-controller-manager-6bcf6c695f-mmnv6   1/1       Running   0          1m
 ~~~
 
-Deploy the [cluster registry](https://github.com/kubernetes/cluster-registry) and the namespace where clusters are registered
-(`kube-multicluster-public`):
+Now we are going to enable some of the federated types needed for our demo application
 
 ~~~sh
-oc apply --validate=false -f vendor/k8s.io/cluster-registry/cluster-registry-crd.yaml
-~~~
-
-The above created:
-
--   The federation CRDs
--   A [StatefulSet](https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/) that deploys the federation controller, and a [Service](https://kubernetes.io/docs/concepts/services-networking/service/) for it.
-
-Now deploy the CRDs that determine which Kubernetes resources are federated across
-the clusters:
-
-~~~sh
-for filename in ./config/enabletypedirectives/*.yaml
+for type in namespaces secrets serviceaccounts services configmaps deployments.apps
 do
-  kubefed2 enable -f "${filename}" --federation-namespace=federation-system
+    kubefedctl enable $type --federation-namespace test-namespace 
 done
 ~~~
 
-After a short while the federation controller manager pod is running:
+<a id="markdown-register-the-clusters" name="register-the-clusters"></a>
+## Register the clusters
 
-~~~sh
-oc get pod -n federation-system
-
-NAME                              READY     STATUS    RESTARTS   AGE
-federation-controller-manager-69cd6d487f-cfp2x   1/1       Running   0          31s
-~~~
-
-<a id="markdown-register-the-clusters-in-the-cluster-registry" name="register-the-clusters-in-the-cluster-registry"></a>
-## Register the clusters in the cluster registry
-
-Verify that there are no clusters in the registry yet (but note
+Verify that there are no clusters yet (but note
 that you can already reference the CRDs for federated clusters):
 
 ~~~sh
-oc get federatedclusters -n federation-system
-oc get clusters --all-namespaces
+oc get federatedclusters -n test-namespace
 
 No resources found.
 ~~~
 
-Now use the `kubefed2` tool to register (*join*) the two clusters:
+Now use the `kubefedctl` tool to register (*join*) the two clusters:
 
 ~~~sh
-kubefed2 join cluster1 \
+kubefedctl join cluster1 \
             --host-cluster-context cluster1 \
             --cluster-context cluster1 \
             --add-to-registry \
             --v=2 \
-            --federation-namespace=federation-system
-kubefed2 join cluster2 \
+            --federation-namespace=test-namespace
+kubefedctl join cluster2 \
             --host-cluster-context cluster1 \
             --cluster-context cluster2 \
             --add-to-registry \
             --v=2 \
-            --federation-namespace=federation-system
+            --federation-namespace=test-namespace
 ~~~
 
-Note that the names of the clusters (`cluster1` and `cluster2`) in the commands above are a refence to the contexts configured in the `oc` client. For this to work as expected you need to make sure that the [client contexts](#configure-client-context-for-cluster-admin-access) have been properly configured with the right access levels and context names. The `--cluster-context` option for `kubefed2 join` can be used to override the refernce to the client context configuration. When the option is not present, `kubefed2` uses the cluster name to identify the client context.
+Note that the names of the clusters (`cluster1` and `cluster2`) in the commands above are a reference to the contexts configured in the `oc` client. For this to work as expected you need to make sure that the [client contexts](#configure-client-context-for-cluster-admin-access) have been properly configured with the right access levels and context names. The `--cluster-context` option for `kubefedctl join` can be used to override the reference to the client context configuration. When the option is not present, `kubefedctl` uses the cluster name to identify the client context.
 
 Verify that the federated clusters are registered and in a ready state (this
 can take a moment):
 
 ~~~sh
-oc describe federatedclusters -n federation-system
+oc describe federatedclusters -n test-namespace
 
 Name:         cluster1
-Namespace:    federation-system
+Namespace:    test-namespace
 Labels:       <none>
 Annotations:  <none>
 API Version:  core.federation.k8s.io/v1alpha1
 Kind:         FederatedCluster
 Metadata:
-  Creation Timestamp:  2019-03-21T17:50:07Z
+  Creation Timestamp:  2019-05-15T16:41:38Z
   Generation:          1
-  Resource Version:    14185
-  Self Link:           /apis/core.federation.k8s.io/v1alpha1/namespaces/federation-system/federatedclusters/cluster1
-  UID:                 c3e2bbb9-4c01-11e9-b494-525400ac0cb8
+  Resource Version:    9108
+  Self Link:           /apis/core.federation.k8s.io/v1alpha1/namespaces/test-namespace/federatedclusters/cluster1
+  UID:                 4f139f4c-7730-11e9-b9cd-525400552436
 Spec:
   Cluster Ref:
     Name:  cluster1
   Secret Ref:
-    Name:  cluster1-t6jqb
+    Name:  cluster1-nrnvf
 Status:
   Conditions:
-    Last Probe Time:       2019-03-21T17:50:48Z
-    Last Transition Time:  2019-03-21T17:50:08Z
+    Last Probe Time:       2019-05-15T16:42:05Z
+    Last Transition Time:  2019-05-15T16:41:44Z
     Message:               /healthz responded with ok
     Reason:                ClusterReady
     Status:                True
@@ -343,26 +330,26 @@ Events:                    <none>
 
 
 Name:         cluster2
-Namespace:    federation-system
+Namespace:    test-namespace
 Labels:       <none>
 Annotations:  <none>
 API Version:  core.federation.k8s.io/v1alpha1
 Kind:         FederatedCluster
 Metadata:
-  Creation Timestamp:  2019-03-21T17:50:34Z
+  Creation Timestamp:  2019-05-15T16:41:40Z
   Generation:          1
-  Resource Version:    14187
-  Self Link:           /apis/core.federation.k8s.io/v1alpha1/namespaces/federation-system/federatedclusters/cluster2
-  UID:                 d4149c9d-4c01-11e9-b494-525400ac0cb8
+  Resource Version:    9110
+  Self Link:           /apis/core.federation.k8s.io/v1alpha1/namespaces/test-namespace/federatedclusters/cluster2
+  UID:                 506516c4-7730-11e9-b9cd-525400552436
 Spec:
   Cluster Ref:
     Name:  cluster2
   Secret Ref:
-    Name:  cluster2-sd64d
+    Name:  cluster2-zwz5b
 Status:
   Conditions:
-    Last Probe Time:       2019-03-21T17:50:48Z
-    Last Transition Time:  2019-03-21T17:50:48Z
+    Last Probe Time:       2019-05-15T16:42:05Z
+    Last Transition Time:  2019-05-15T16:41:44Z
     Message:               /healthz responded with ok
     Reason:                ClusterReady
     Status:                True
@@ -376,42 +363,14 @@ Events:                    <none>
 Now that we have federation installed, let’s deploy an example app in both
 clusters through the federation control plane.
 
-<a id="markdown-create-a-federated-namespace" name="create-a-federated-namespace"></a>
-## Create a federated namespace
-
-Create a test project (`test-namespace`) and add a federated placement policy
-for it:
-
-~~~sh
-cat << EOF | oc create -f -
-apiVersion: v1
-kind: List
-items:
-- apiVersion: v1
-  kind: Namespace
-  metadata:
-    name: test-namespace
-- apiVersion: types.federation.k8s.io/v1alpha1
-  kind: FederatedNamespace
-  metadata:
-    name: test-namespace
-    namespace: test-namespace
-  spec:
-    placement:
-      clusterNames:
-      - cluster1
-      - cluster2
-EOF
-~~~
-
 Verify that the namespace is present in both clusters now:
 
 ~~~sh
-oc --context=cluster1 get ns | grep test
-oc --context=cluster2 get ns | grep test
+oc --context=cluster1 get ns | grep test-namespace
+oc --context=cluster2 get ns | grep test-namespace
 
-test-namespace                 Active    7s
-test-namespace                 Active    7s
+test-namespace                 Active    4m
+test-namespace                 Active    1m
 ~~~
 
 <a id="markdown-deploy-the-application" name="deploy-the-application"></a>
@@ -434,7 +393,6 @@ on `cluster2`.
 Instantiate all these federated resources:
 
 ~~~sh
-cd ../
 oc apply -R -f sample-app
 ~~~
 
@@ -456,49 +414,47 @@ done
 Verify that the application can be accessed:
 
 ~~~sh
-host=$(oc whoami --show-server | sed -e 's#https://##' -e 's/:8443//')
-port=$(oc get svc -n test-namespace test-service -o jsonpath={.spec.ports[0].nodePort})
-
-curl -I $host:$port
+for cluster in cluster1 cluster2; do
+    echo ------------ ${cluster} ------------
+    host=$(oc --context $cluster whoami --show-server | sed -e 's#https://##' -e 's/:8443//')
+    port=$(oc --context $cluster get svc -n test-namespace test-service -o jsonpath={.spec.ports[0].nodePort})
+    curl -I $host:$port
+done
 ~~~
 
 <a id="markdown-modify-placement" name="modify-placement"></a>
 ## Modify placement
 
-Now modify the test namespace placement policy to remove `cluster2`, leaving it
+Now modify the `test-deployment` federated deployment placement policy to remove `cluster2`, leaving it
 only active on `cluster1`:
 
 ~~~sh
-oc -n test-namespace patch federatednamespace test-namespace \
+oc -n test-namespace patch federateddeployment test-deployment \
     --type=merge -p '{"spec":{"placement":{"clusterNames": ["cluster1"]}}}'
 ~~~
 
-Observe how the federated resources are now only present in `cluster1`:
+Observe how the federated deployment is now only present in `cluster1`:
 
 ~~~sh
-for resource in configmaps secrets deployments services; do
-    for cluster in cluster1 cluster2; do
-        echo ------------ ${cluster} ${resource} ------------
-        oc --context=${cluster} -n test-namespace get ${resource}
-    done
+for cluster in cluster1 cluster2; do
+    echo ------------ ${cluster} deployments ------------
+    oc --context=${cluster} -n test-namespace get deployments
 done
 ~~~
 
-Now add `cluster2` back to the federated namespace placement:
+Now add `cluster2` back to the federated deployment placement:
 
 ~~~sh
-oc -n test-namespace patch federatednamespace test-namespace \
+oc -n test-namespace patch federateddeployment test-deployment \
     --type=merge -p '{"spec":{"placement":{"clusterNames": ["cluster1", "cluster2"]}}}'
 ~~~
 
-And verify that the federated resources were deployed on both clusters again:
+And verify that the federated deployment was deployed on both clusters again:
 
 ~~~sh
-for resource in configmaps secrets deployments services; do
-    for cluster in cluster1 cluster2; do
-        echo ------------ ${cluster} ${resource} ------------
-        oc --context=${cluster} -n test-namespace get ${resource}
-    done
+for cluster in cluster1 cluster2; do
+    echo ------------ ${cluster} deployments ------------
+    oc --context=${cluster} -n test-namespace get deployments
 done
 ~~~
 
@@ -508,7 +464,7 @@ done
 To clean up only the test application run:
 
 ~~~sh
-oc delete ns test-namespace
+oc delete -R -f sample-app
 ~~~
 
 This leaves the two clusters with federation deployed. If you want to remove everything run:
@@ -530,9 +486,9 @@ have created additional entries in your `oc` client configuration (`~/.kube/conf
 This walkthrough does not go into detail of the components and resources involved
 in cluster federation. Feel free to explore the repository to review the YAML files
 that configure Federation and deploy the sample application. See also the upstream
-federation-v2 repo and its [user guide](https://github.com/kubernetes-sigs/federation-v2/blob/master/docs/userguide.md), on which this guide is based.
+kubefed repository and its [user guide](https://github.com/kubernetes-sigs/kubefed/blob/master/docs/userguide.md), on which this guide is based.
 
-Beyond that: the CDK/minishift provides us with a quick and easy environment for
+Beyond that: the CDK/minishift proides us with a quick and easy environment for
 testing, but it has limitations. More advanced aspects of cluster federation
 like managing ingress traffic or storage rely on supporting infrastructure for
 the clusters that is not available in minishift. These will be topics for

--- a/README-ocp4.md
+++ b/README-ocp4.md
@@ -2,57 +2,56 @@
 
 <!-- TOC depthFrom:1 insertAnchor:true orderedList:true -->
 
-1. [Introduction](#introduction)
-2. [Pre-requisites](#pre-requisites)
-    1. [Install the kubefed2 binary](#install-the-kubefed2-binary)
-    2. [Download the example code](#download-the-example-code)
-3. [Federation deployment](#federation-deployment)
-    1. [Create the two OpenShift clusters](#create-the-two-openshift-clusters)
-        1. [Configure client context for cluster admin access](#configure-client-context-for-cluster-admin-access)
-    2. [Deploy Federation](#deploy-federation)
-    3. [Register the clusters in the cluster registry](#register-the-clusters-in-the-cluster-registry)
-4. [Example application](#example-application)
-    1. [Deploy the application](#deploy-the-application)
-    2. [Verify that the application is running](#verify-that-the-application-is-running)
-    3. [Modify placement](#modify-placement)
-5. [Clean up](#clean-up)
-6. [What’s next?](#whats-next)
+- [Introduction](#introduction)
+- [Prerequisites](#prerequisites)
+  - [Install the kubefedctl binary](#install-the-kubefedctl-binary)
+  - [Download the example code](#download-the-example-code)
+- [Federation deployment](#federation-deployment)
+  - [Create the two OpenShift clusters](#create-the-two-openshift-clusters)
+  - [Configure client context for cluster admin access](#configure-client-context-for-cluster-admin-access)
+  - [Deploy Federation](#deploy-federation)
+  - [Register the clusters](#register-the-clusters)
+- [Example application](#example-application)
+  - [Deploy the application](#deploy-the-application)
+  - [Verify that the application is running](#verify-that-the-application-is-running)
+  - [Modify placement](#modify-placement)
+- [Clean up](#clean-up)
+- [What’s next?](#whats-next)
 
 <!-- /TOC -->
 
 <a id="markdown-introduction" name="introduction"></a>
 # Introduction
 
-This demo is a simple deployment of [Federation v2 Operator](https://operatorhub.io/operator/federation.v0.0.6) on two OpenShift
-clusters. A sample application is deployed to both clusters through the
-federation controller.
+This demo is a simple deployment of [Federation Operator](https://operatorhub.io/operator/alpha/federation.v0.0.10) on two OpenShift
+clusters. A sample application is deployed to both clusters through the Federation controller.
 
 <a id="markdown-pre-requisites" name="pre-requisites"></a>
 # Prerequisites
 
-The Federation Operator requires at least one [OpenShift Container Platform](https://www.openshift.com/) 4.0 cluster.
+The Federation Operator requires at least one [OpenShift Container Platform](https://www.openshift.com/) 4.1 cluster.
 
-This walkthrough will use 2 OCP 4.0 clusters deployed using the [developer preview on AWS](https://cloud.openshift.com/clusters/install).
+This walkthrough will use 2 OCP 4.1 clusters deployed using the [developer preview on AWS](https://cloud.openshift.com/clusters/install).
 
-<a id="markdown-install-the-kubefed2-binary" name="install-the-kubefed2-binary"></a>
-## Install the kubefed2 binary
+<a id="markdown-install-the-kubefedctl-binary" name="install-the-kubefedctl-binary"></a>
+## Install the kubefedctl binary
 
-The `kubefed2` tool manages federated cluster registration. Download the
-v0.0.7 release and unpack it into a directory in your PATH (the
+The `kubefedctl` tool manages federated cluster registration. Download the
+v0.0.10 release and unpack it into a directory in your PATH (the
 example uses `$HOME/bin`):
 
 ~~~sh
-curl -LOs https://github.com/kubernetes-sigs/federation-v2/releases/download/v0.0.7/kubefed2.tar.gz
-tar xzf kubefed2.tar.gz -C ~/bin
-rm -f kubefed2.tar.gz
+curl -LOs https://github.com/kubernetes-sigs/kubefed/releases/download/v0.0.10/kubefedctl.tgz
+tar xzf kubefedctl.tgz -C ~/bin
+rm -f kubefedctl.tgz
 ~~~
 
-Verify that `kubefed2` is working:
+Verify that `kubefedctl` is working:
 
 ~~~sh
-kubefed2 version
+kubefedctl version
 
-kubefed2 version: version.Info{Version:"v0.0.7", GitCommit:"83b778b6d92a7929efb7687d3d3d64bf0b3ad3bc", GitTreeState:"clean", BuildDate:"2019-03-19T18:40:46Z", GoVersion:"go1.11.2", Compiler:"gc", Platform:"linux/amd64"}
+kubefedctl version: version.Info{Version:"v0.0.10-dirty", GitCommit:"71d233ede685707df554ef653e06bf7f0229415c", GitTreeState:"dirty", BuildDate:"2019-05-06T22:30:31Z", GoVersion:"go1.11.2", Compiler:"gc", Platform:"linux/amd64"}
 ~~~
 
 <a id="markdown-download-the-example-code" name="download-the-example-code"></a>
@@ -61,7 +60,7 @@ kubefed2 version: version.Info{Version:"v0.0.7", GitCommit:"83b778b6d92a7929efb7
 Clone the demo code to your local machine:
 
 ~~~sh
-git clone --recurse-submodules https://github.com/openshift/federation-dev.git
+git clone https://github.com/openshift/federation-dev.git
 cd federation-dev/
 ~~~
 
@@ -71,14 +70,14 @@ cd federation-dev/
 <a id="markdown-create-the-two-openshift-clusters" name="create-the-two-openshift-clusters"></a>
 ## Create the two OpenShift clusters
 
-Follow the [developer preview instructions](https://cloud.openshift.com/clusters/install) for installing two OpenShift 4.0 clusters on AWS.
+Follow the [developer preview instructions](https://cloud.redhat.com/openshift/install) for installing two OpenShift 4.1 clusters on AWS.
 
 Once both clusters are up and running, we are going to merge the Kubernetes configurations files so we have a connection to both clusters using the same Kubeconfig file.
 
 <a id="markdown-configure-client-context-for-cluster-admin-access" name="configure-client-context-for-cluster-admin-access"></a>
 ## Configure client context for cluster admin access
 
-The installer has created a `kubeconfig` file for each cluster, we are going to merge them in the same file so we can use that file later with `kubefed2` tool.
+The installer has created a `kubeconfig` file for each cluster, we are going to merge them in the same file so we can use that file later with `kubefedctl` tool.
 
 First, we will rename the `admin` context and then we will rename the admin user so when we merge the two kubeconfig files both admin users are present.
 
@@ -108,7 +107,7 @@ $ oc whoami
 system:admin
 ~~~
 
-The presence and unique naming of the client contexts are important because the `kubefed2` tool uses them to manage cluster registration, and they are referenced by context name.
+The presence and unique naming of the client contexts are important because the `kubefedctl` tool uses them to manage cluster registration, and they are referenced by context name.
 
 <a id="markdown-deploy-federation" name="deploy-federation"></a>
 ## Deploy Federation
@@ -117,7 +116,7 @@ Federation target clusters do not require federation to be installed on them at
 all, but for convenience, we will use one of the clusters (`cluster1`) to host
 the federation control plane.
 
-At the moment, the Federation V2 Operator only works in namespace-scoped mode, in the future cluster-scoped mode will be supported as well by the operator.
+At the moment, the Federation Operator only works in namespace-scoped mode, in the future cluster-scoped mode will be supported as well by the operator.
 
 In order to deploy the operator, we are going to use `Operator Hub` within the OCP4 WebUI.
 
@@ -132,9 +131,9 @@ In order to deploy the operator, we are going to use `Operator Hub` within the O
    1. On the left panel click `Catalog -> Operator Hub`
    2. Select `Federation` from operator list
    3. If a warning about use of Community Operators is shown click `Continue`
-   3. Click `Install`
-   4. Make sure `test-namespace` is selected as destination namespace
-   5. Click `Subscribe`
+   4. Click `Install`
+   5. Make sure `test-namespace` is selected as destination namespace
+   6. Click `Subscribe`
 4. Check the Operator Subscription status
    1. On the left panel click `Catalog -> Operator Management`
    2. Click `Operator Subscriptions` tab
@@ -146,7 +145,7 @@ If everything is okay, we should have the federation controller running in the n
 oc --context=cluster1 -n test-namespace get pods
 
 NAME                                             READY     STATUS    RESTARTS   AGE
-federation-controller-manager-744f57ccff-q4f6k   1/1       Running   0          28m
+federation-controller-manager-744f57ccff-q4f6k  1/1       Running   0          3m18s
 ~~~
 
 Now we are going to enable some of the federated types needed for our demo application
@@ -154,53 +153,40 @@ Now we are going to enable some of the federated types needed for our demo appli
 ~~~sh
 for type in namespaces secrets serviceaccounts services configmaps deployments.apps
 do
-    kubefed2 enable $type --federation-namespace test-namespace --registry-namespace test-namespace
+    kubefedctl enable $type --federation-namespace test-namespace 
 done
 ~~~
 
-**Warning**:
+<a id="markdown-register-the-clusters" name="register-the-clusters"></a>
+## Register the clusters
 
-If you get this error while enabling new types, you are hitting this [bug](https://bugzilla.redhat.com/show_bug.cgi?id=1692869) (will be fixed in 0.0.8 release):
-
-```
-F0410 15:19:13.669674   22623 enable.go:112] error: Error initializing validation schema accessor: Error loading openapi schema: SchemaError(io.k8s.federation.types.v1alpha1.FederatedDeployment.spec.retainReplicas): Unknown primitive type: "bool"
-```
-
-<a id="markdown-register-the-clusters-in-the-cluster-registry" name="register-the-clusters-in-the-cluster-registry"></a>
-## Register the clusters in the cluster registry
-
-Verify that there are no clusters in the registry yet (but note
+Verify that there are no clusters yet (but note
 that you can already reference the CRDs for federated clusters):
 
 ~~~sh
 oc get federatedclusters -n test-namespace
-oc get clusters --all-namespaces
 
 No resources found.
 ~~~
 
-Now use the `kubefed2` tool to register (*join*) the two clusters:
+Now use the `kubefedctl` tool to register (*join*) the two clusters:
 
 ~~~sh
-kubefed2 join cluster1 \
+kubefedctl join cluster1 \
             --host-cluster-context cluster1 \
             --cluster-context cluster1 \
             --add-to-registry \
             --v=2 \
-            --federation-namespace=test-namespace \
-            --registry-namespace=test-namespace \
-            --limited-scope=true
-kubefed2 join cluster2 \
+            --federation-namespace=test-namespace
+kubefedctl join cluster2 \
             --host-cluster-context cluster1 \
             --cluster-context cluster2 \
             --add-to-registry \
             --v=2 \
-            --federation-namespace=test-namespace \
-            --registry-namespace=test-namespace \
-            --limited-scope=true
+            --federation-namespace=test-namespace
 ~~~
 
-Note that the names of the clusters (`cluster1` and `cluster2`) in the commands above are a refence to the contexts configured in the `oc` client. For this process to work as expected you need to make sure that the [client contexts](#configure-client-context-for-cluster-admin-access) have been properly configured with the right access levels and context names. The `--cluster-context` option for `kubefed2 join` can be used to override the refernce to the client context configuration. When the option is not present, `kubefed2` uses the cluster name to identify the client context.
+Note that the names of the clusters (`cluster1` and `cluster2`) in the commands above are a reference to the contexts configured in the `oc` client. For this process to work as expected you need to make sure that the [client contexts](#configure-client-context-for-cluster-admin-access) have been properly configured with the right access levels and context names. The `--cluster-context` option for `kubefedctl join` can be used to override the reference to the client context configuration. When the option is not present, `kubefedctl` uses the cluster name to identify the client context.
 
 Verify that the federated clusters are registered and in a ready state (this
 can take a moment):
@@ -215,27 +201,30 @@ Annotations:  <none>
 API Version:  core.federation.k8s.io/v1alpha1
 Kind:         FederatedCluster
 Metadata:
-  Creation Timestamp:  2019-03-25T19:38:11Z
+  Creation Timestamp:  2019-05-15T10:48:39Z
   Generation:          1
-  Resource Version:    111057
+  Resource Version:    236828
   Self Link:           /apis/core.federation.k8s.io/v1alpha1/namespaces/test-namespace/federatedclusters/cluster1
-  UID:                 8612a72f-4f35-11e9-953c-02a016278e96
+  UID:                 ff6a7223-76fe-11e9-89e9-02fb71b1e13a
 Spec:
   Cluster Ref:
     Name:  cluster1
   Secret Ref:
-    Name:  cluster1-2mj4t
+    Name:  cluster1-kx98r
 Status:
   Conditions:
-    Last Probe Time:       2019-03-25T19:39:37Z
-    Last Transition Time:  2019-03-25T19:38:17Z
+    Last Probe Time:       2019-05-15T10:50:52Z
+    Last Transition Time:  2019-05-15T10:48:41Z
     Message:               /healthz responded with ok
     Reason:                ClusterReady
     Status:                True
     Type:                  Ready
   Region:                  us-east-1
-  Zone:                    us-east-1a
-Events:                    <none>
+  Zones:
+    us-east-1a
+    us-east-1b
+    us-east-1c
+Events:  <none>
 
 
 Name:         cluster2
@@ -245,27 +234,30 @@ Annotations:  <none>
 API Version:  core.federation.k8s.io/v1alpha1
 Kind:         FederatedCluster
 Metadata:
-  Creation Timestamp:  2019-03-25T19:38:45Z
+  Creation Timestamp:  2019-05-15T10:49:35Z
   Generation:          1
-  Resource Version:    111058
+  Resource Version:    236829
   Self Link:           /apis/core.federation.k8s.io/v1alpha1/namespaces/test-namespace/federatedclusters/cluster2
-  UID:                 9a762e4d-4f35-11e9-9909-0eebed9414aa
+  UID:                 211ba702-76ff-11e9-a071-12235e364a80
 Spec:
   Cluster Ref:
     Name:  cluster2
   Secret Ref:
-    Name:  cluster2-mch2g
+    Name:  cluster2-6dr6x
 Status:
   Conditions:
-    Last Probe Time:       2019-03-25T19:39:37Z
-    Last Transition Time:  2019-03-25T19:38:57Z
+    Last Probe Time:       2019-05-15T10:50:52Z
+    Last Transition Time:  2019-05-15T10:49:41Z
     Message:               /healthz responded with ok
     Reason:                ClusterReady
     Status:                True
     Type:                  Ready
-  Region:                  us-east-1
-  Zone:                    us-east-1a
-Events:                    <none>
+  Region:                  us-east-2
+  Zones:
+    us-east-2a
+    us-east-2b
+    us-east-2c
+Events:  <none>
 ~~~
 
 <a id="markdown-example-application" name="example-application"></a>
@@ -280,8 +272,8 @@ Verify that our test-namespace is present in both clusters now:
 oc --context=cluster1 get ns | grep test-namespace
 oc --context=cluster2 get ns | grep test-namespace
 
-test-namespace                 Active    54s
-test-namespace                 Active    55s
+test-namespace                 Active    36m
+test-namespace                 Active    3m21s
 ~~~
 
 The container image we will use for our example application (nginx) requires the
@@ -304,10 +296,9 @@ The sample application includes the following resources:
 -   A [Service](https://kubernetes.io/docs/concepts/services-networking/service/) of type NodePort for nginx.
 -   A sample [ConfigMap](https://kubernetes.io/docs/tasks/configure-pod-container/configure-pod-configmap/), [Secret](https://kubernetes.io/docs/concepts/configuration/secret/) and [ServiceAccount](https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/). These are not actually used by
     the sample application (static nginx) but are included to illustrate how
-    federation would assist with more complex applications.
+    Kubefed would assist with more complex applications.
 
-The [sample-app directory](./sample-app) contains definitions to deploy these resources. For
-each of them there is a resource template and a placement policy, and some of
+The [sample-app directory](./sample-app) contains definitions to deploy these resources. For each of them there is a resource template and a placement policy, and some of
 them also have overrides. For example: the [sample nginx deployment template](./sample-app/federateddeployment.yaml)
 specifies 3 replicas, but there is also an override that sets the replicas to 5
 on `cluster2`.
@@ -337,7 +328,7 @@ Verify that the application can be accessed:
 
 ~~~sh
 for cluster in cluster1 cluster2; do
-  echo ------------ ${cluster} test ------------
+  echo ------------ ${cluster} ------------
   oc --context=${cluster} -n test-namespace expose service test-service
   url="http://$(oc --context=${cluster} -n test-namespace get route test-service -o jsonpath='{.spec.host}')"
   curl -I $url
@@ -408,7 +399,7 @@ This leaves the two clusters with federation deployed. If you want to disable fe
 This walkthrough does not go into detail about the components and resources involved
 in cluster federation. Feel free to explore the repository to review the YAML files
 that configure Federation and deploy the sample application. See also the upstream
-federation-v2 repo and its [user guide](https://github.com/kubernetes-sigs/federation-v2/blob/master/docs/userguide.md), on which this guide is based.
+ke REubefed repository and its [user guide](https://github.com/kubernetes-sigs/kubefed/blob/master/docs/userguide.md), on which this guide is based.
 
 Beyond that: More advanced aspects of cluster federation
 like managing ingress traffic or storage rely on supporting infrastructure for

--- a/README.md
+++ b/README.md
@@ -1,24 +1,26 @@
 # Federation Dev
 This repository is a place holder for various demonstrations, labs, and examples
-of the use of Federation V2.
+of the use of Kubefed.
 
 ## What is Federation
 Put quite simply, Federation is the process of connecting one or more Kubernetes clusters. The explanation from OperatorHub states
 ``
 Kubernetes Federation is a tool to sync (aka "federate") a set of Kubernetes objects from a "source" into a set of other clusters. Common use-cases include federating Namespaces across all of your clusters or rolling out an application across several geographically distributed clusters. The Kubernetes Federation Operator runs all of the components under the hood to quickly get up and running with this powerful concept. Federation is a key part of any Hybrid Cloud capability.
 ``
-There are two ways two use Federation V2 currently: Namespace and Cluster scoped.
+There are two ways two use Kubefed currently: Namespace and Cluster scoped.
 
 ### Namespace Scoped labs
 Namespace scoped Federation will initially be the only supported mechanism for federating
 multiple OpenShift/Kubernetes environments. Namespace scoped Federation uses OperatorHub
-which is included within OpenShift to install the Federation Operator.</br>
-A simple application federated [OpenShift Container Plaform 4](./README-ocp4.md)</br>
-Federated MongoDB and *pacman* [Federating an application with a Database](./federated-mongodb/README.md)
+which is included within OpenShift 4.1 to install the Federation Operator.
 
+* A simple application federated [OpenShift Container Plaform 4](./README-ocp4.md)
+* Federated MongoDB and *Pacman* [Federating an application with a Database](./federated-mongodb/README.md)
 
-### Cluster Scoped labs
-Cluster scoped Federation using an Operator is still in progress. The examples below
-will run through the procedures of manually configuring cluster scoped Federation.</br>
-Using [minishift](./README-minishift.md)<br/>
-Using [cdk](./README-minishift.md)
+OpenShift 3.11 versions for the simple application scenario are also available:
+
+* Using [Minishift](./README-minishift.md)
+* Using [CDK](./README-minishift.md)
+
+### Cluster Scoped
+At the moment cluster-scoped federation is not supported by the operator. Once the cluster scoped is enabled via the operator we will update the instructions to cover that user case as well.

--- a/federated-mongodb/README.md
+++ b/federated-mongodb/README.md
@@ -1,5 +1,5 @@
 # Federated MongoDB
-The files within this directory are used with the Federation V2 operator to show
+The files within this directory are used with the Federation operator to show
 MongoDB running on multiple OpenShift clusters. An accompanying video
 is [here](https://youtu.be/StNJupmZ5Mo). This demonstration uses 3 OpenShift 4 clusters. It is assumed that 3 OpenShift
 clusters have already been deployed using of the deployment mechanisms defined at
@@ -20,7 +20,7 @@ Once the OperatorHub loads click Federation </br>
 
 Once Federation has been chosen, information about the Operator will appear. It is
 important to take note of the Operator Version as this will be needed when deciding
-which version of Kubefed2 to use.
+which version of Kubefedctl to use.
 
 Select Install</br>
 ![Install Federation](../images/install.png)
@@ -49,47 +49,47 @@ export KUBECONFIG=`pwd`/aws-east1-east2-west2
 oc config set-context east1
 ~~~
 
-## Install the kubefed2 binary
+## Install the kubefedctl binary
 
-The `kubefed2` tool manages federated cluster registration. Download the
-v0.0.8 release and unpack it into a directory in your PATH (the
+The `kubefedctl` tool manages federated cluster registration. Download the
+v0.0.10 release and unpack it into a directory in your PATH (the
 example uses `$HOME/bin`):
 
 NOTE: The version may change as the operator matures. Verify that the version of
-Federation matches the version of `kubefed2`.
+Federation matches the version of `kubefedctl`.
 
 ~~~sh
-curl -LOs https://github.com/kubernetes-sigs/federation-v2/releases/download/v0.0.8/kubefed2.tgz
-tar xzf kubefed2.tgz -C ~/bin
-rm -f kubefed2.tgz
+curl -LOs https://github.com/kubernetes-sigs/kubefed/releases/download/v0.0.10/kubefedctl.tgz
+tar xzf kubefedctl.tgz -C ~/bin
+rm -f kubefedctl.tgz
 ~~~
 
-Verify that `kubefed2` is working:
+Verify that `kubefedctl` is working:
 ~~~sh
-kubefed2 version
+kubefedctl version
 
-kubefed2 version: version.Info{Version:"v0.0.8", GitCommit:"0d12bc3d438b61d9966c79a19f12b01d00d95aae", GitTreeState:"clean", BuildDate:"2019-04-11T04:26:34Z", GoVersion:"go1.11.2", Compiler:"gc", Platform:"linux/amd64"}
+kubefedctl version: version.Info{Version:"v0.0.10-dirty", GitCommit:"71d233ede685707df554ef653e06bf7f0229415c", GitTreeState:"dirty", BuildDate:"2019-05-06T22:30:31Z", GoVersion:"go1.11.2", Compiler:"gc", Platform:"linux/amd64"}
 ~~~
 
 ## Joining Clusters
-Now that the `kubefed2` binary has been acquired the next step is joining the clusters.
-`kubefed2` binary utilizes the contexts and clusters within `kubeconfig` when defining the clusters.
+Now that the `kubefedctl` binary has been acquired the next step is joining the clusters.
+`kubefedctl` binary utilizes the contexts and clusters within `kubeconfig` when defining the clusters.
 
 Using the `kubeconfig` file that was generated, verify the Operator has been successfully deployed.
 ~~~sh
 $ oc get csv -n federated-mongo
 NAME                DISPLAY      VERSION   REPLACES   PHASE
-federation.v0.0.8   Federation   0.0.8                Succeeded
+federation.v0.0.10   Federation   0.0.10                Succeeded
 ~~~
-The next step is to federate the clusters using `kubefed2`.
+The next step is to federate the clusters using `kubefedctl`.
 ~~~sh
-kubefed2 join east1 --host-cluster-context east1 --add-to-registry --v=2 --federation-namespace=federated-mongo --registry-namespace=federated-mongo --limited-scope=true
-kubefed2 join east2 --host-cluster-context east1 --add-to-registry --v=2 --federation-namespace=federated-mongo --registry-namespace=federated-mongo --limited-scope=true
-kubefed2 join west2 --host-cluster-context east1 --add-to-registry --v=2 --federation-namespace=federated-mongo --registry-namespace=federated-mongo --limited-scope=true
+kubefedctl join east1 --host-cluster-context east1 --add-to-registry --v=2 --federation-namespace=federated-mongo
+kubefedctl join east2 --host-cluster-context east1 --add-to-registry --v=2 --federation-namespace=federated-mongo
+kubefedctl join west2 --host-cluster-context east1 --add-to-registry --v=2 --federation-namespace=federated-mongo
 
-for type in namespaces clusterroles.rbac.authorization.k8s.io deployments.apps ingresses.extensions jobs replicasets.apps secrets serviceaccounts services persistentvolumeclaims configmaps clusterrolebindings.rbac.authorization.k8s.io
+for type in namespaces deployments.apps ingresses.extensions secrets serviceaccounts services persistentvolumeclaims configmaps
 do
-  kubefed2 enable $type --federation-namespace federated-mongo --registry-namespace federated-mongo
+  kubefedctl enable $type --federation-namespace federated-mongo
 done
 ~~~
 
@@ -191,8 +191,8 @@ cat mongodb-key.pem mongodb.pem > mongo.pem
 
 ## Deploying MongoDB
 There are many different types of federated objects but they are somewhat similar to those
-non-federated objects. For more information about federated objects see the following  [examples](https://github.com/kubernetes-sigs/federation-v2/tree/master/example/sample1) and
-the [user guide](https://github.com/kubernetes-sigs/federation-v2/blob/master/docs/userguide.md).
+non-federated objects. For more information about federated objects see the following  [examples](https://github.com/kubernetes-sigs/kubefed/tree/master/example/sample1) and
+the [user guide](https://github.com/kubernetes-sigs/kubefed/blob/master/docs/userguide.md).
 
 
 The first step is to clone the demo code to your local machine:

--- a/federated-pacman/README.md
+++ b/federated-pacman/README.md
@@ -1,5 +1,5 @@
-# Federation Pacman
-The files within this directory are used with the Federation V2 operator to show
+ # Federation Pacman
+The files within this directory are used with the Federation operator to show
 an application balancing and moving between OpenShift clusters. An accompanying video
 is [here](https://youtu.be/avCPAJms3Fc). This demonstration uses 3 OpenShift 4 clusters. It is assumed that 3 OpenShift
 clusters have already been deployed using of the deployment mechanisms defined at
@@ -21,7 +21,7 @@ Once the OperatorHub loads click Federation </br>
 
 Once Federation has been chosen, information about the Operator will appear. It is
 important to take note of the Operator Version as this will be needed when deciding
-which version of Kubefed2 to use.
+which version of Kubefedctl to use.
 
 Select Install</br>
 ![Install Federation](../images/install.png)
@@ -50,47 +50,47 @@ export KUBECONFIG=`pwd`/aws-east1-east2-west2
 oc config set-context east1
 ~~~
 
-## Install the `kubefed2` binary
+## Install the `kubefedctl` binary
 
-The `kubefed2` tool manages federated cluster registration. Download the
-v0.0.8 release and unpack it into a directory in your PATH (the
+The `kubefedctl` tool manages federated cluster registration. Download the
+v0.0.10 release and unpack it into a directory in your PATH (the
 example uses `$HOME/bin`):
 
 NOTE: The version may change as the operator matures. Verify that the version of
-Federation matches the version of `kubefed2`.
+Federation matches the version of `kubefedctl`.
 
 ~~~sh
-curl -LOs https://github.com/kubernetes-sigs/federation-v2/releases/download/v0.0.8/kubefed2.tgz
-tar xzf kubefed2.tgz -C ~/bin
-rm -f kubefed2.tgz
+curl -LOs https://github.com/kubernetes-sigs/kubefed/releases/download/v0.0.10/kubefedctl.tgz
+tar xzf kubefedctl.tgz -C ~/bin
+rm -f kubefedctl.tgz
 ~~~
 
-Verify that `kubefed2` is working:
+Verify that `kubefedctl` is working:
 ~~~sh
-kubefed2 version
+kubefedctl version
 
-kubefed2 version: version.Info{Version:"v0.0.8", GitCommit:"0d12bc3d438b61d9966c79a19f12b01d00d95aae", GitTreeState:"clean", BuildDate:"2019-04-11T04:26:34Z", GoVersion:"go1.11.2", Compiler:"gc", Platform:"linux/amd64"}
+kubefedctl version: version.Info{Version:"v0.0.10-dirty", GitCommit:"71d233ede685707df554ef653e06bf7f0229415c", GitTreeState:"dirty", BuildDate:"2019-05-06T22:30:31Z", GoVersion:"go1.11.2", Compiler:"gc", Platform:"linux/amd64"}
 ~~~
 
 ## Joining Clusters
-Now that the `kubefed2` binary has been acquired the next step is joining the clusters.
-`kubefed2` binary utilizes the contexts and clusters within `kubeconfig` when defining the clusters.
+Now that the `kubefedctl` binary has been acquired the next step is joining the clusters.
+`kubefedctl` binary utilizes the contexts and clusters within `kubeconfig` when defining the clusters.
 
 Using the `kubeconfig` file that was generated, verify the Operator has been successfully deployed.
 ~~~sh
 $ oc get csv -n pacman
 NAME                DISPLAY      VERSION   REPLACES   PHASE
-federation.v0.0.8   Federation   0.0.8                Succeeded
+federation.v0.0.10   Federation   0.0.10                Succeeded
 ~~~
-The next step is to federate the clusters using `kubefed2`.
+The next step is to federate the clusters using `kubefedctl`.
 ~~~sh
-kubefed2 join east1 --host-cluster-context east1 --add-to-registry --v=2 --federation-namespace=pacman --registry-namespace=pacman --limited-scope=true
-kubefed2 join east2 --host-cluster-context east1 --add-to-registry --v=2 --federation-namespace=pacman --registry-namespace=pacman --limited-scope=true
-kubefed2 join west2 --host-cluster-context east1 --add-to-registry --v=2 --federation-namespace=pacman --registry-namespace=pacman --limited-scope=true
+kubefedctl join east1 --host-cluster-context east1 --add-to-registry --v=2 --federation-namespace=pacman
+kubefedctl join east2 --host-cluster-context east1 --add-to-registry --v=2 --federation-namespace=pacman
+kubefedctl join west2 --host-cluster-context east1 --add-to-registry --v=2 --federation-namespace=pacman
 
-for type in namespaces clusterroles.rbac.authorization.k8s.io deployments.apps ingresses.extensions jobs replicasets.apps secrets serviceaccounts services configmaps clusterrolebindings.rbac.authorization.k8s.io
+for type in namespaces deployments.apps ingresses.extensions secrets serviceaccounts services configmaps
 do
-  kubefed2 enable $type --federation-namespace pacman --registry-namespace pacman
+  kubefedctl enable $type --federation-namespace pacman
 done
 ~~~
 
@@ -106,8 +106,8 @@ west2   True
 ## Deploying *Pacman*
 Now that the clusters are federated it is time to deploy the *pacman* application.
 There are many different types of federated objects but they are somewhat similar to those
-non-federated objects. For more information about federated objects see the following  [examples](https://github.com/kubernetes-sigs/federation-v2/tree/master/example/sample1) and
-the [user guide](https://github.com/kubernetes-sigs/federation-v2/blob/master/docs/userguide.md).
+non-federated objects. For more information about federated objects see the following  [examples](https://github.com/kubernetes-sigs/kubefed/tree/master/example/sample1) and
+the [user guide](https://github.com/kubernetes-sigs/kubefed/blob/master/docs/userguide.md).
 
 For the *pacman* application, the first step is to modify the `pacman-federated-deployment-rs.yaml` file to reflect
 the MongoDB endpoint. The MongoDB endpoint is used to save scores from the game.

--- a/olm/01-olm.yaml
+++ b/olm/01-olm.yaml
@@ -1,0 +1,1442 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: olm
+  
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: operators
+  
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: system:controller:operator-lifecycle-manager
+rules:
+- apiGroups: ["*"]
+  resources: ["*"]
+  verbs: ["*"]
+- nonResourceURLs: ["*"]
+  verbs: ["*"]
+---
+kind: ServiceAccount
+apiVersion: v1
+metadata:
+  name: olm-operator-serviceaccount
+  namespace: olm
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: olm-operator-binding-olm
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:controller:operator-lifecycle-manager
+subjects:
+- kind: ServiceAccount
+  name: olm-operator-serviceaccount
+  namespace: olm
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: clusterserviceversions.operators.coreos.com
+  annotations:
+    displayName: Operator Version
+    description: Represents an Operator that should be running on the cluster, including requirements and install strategy.
+spec:
+  names:
+    plural: clusterserviceversions
+    singular: clusterserviceversion
+    kind: ClusterServiceVersion
+    listKind: ClusterServiceVersionList
+    shortNames:
+    - csv
+    - csvs
+    categories:
+    - olm
+  additionalPrinterColumns:
+  - name: Display
+    type: string
+    description: The name of the CSV
+    JSONPath: .spec.displayName
+  - name: Version
+    type: string
+    description: The version of the CSV
+    JSONPath: .spec.version
+  - name: Replaces
+    type: string
+    description: The name of a CSV that this one replaces
+    JSONPath: .spec.replaces
+  - name: Phase
+    type: string
+    JSONPath: .status.phase
+  group: operators.coreos.com
+  version: v1alpha1
+  versions:
+    - name: v1alpha1
+      served: true
+      storage: true
+  scope: Namespaced
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      properties:
+        spec:
+          type: object
+          description: Spec for a ClusterServiceVersion
+          required:
+          - displayName
+          - install
+          properties:
+            displayName:
+              type: string
+              description: Human readable name of the application that will be displayed in the ALM UI
+
+            description:
+              type: string
+              description: Human readable description of what the application does
+
+            minKubeVersion:
+              type: string
+              description: Minimum kubernetes version requirement on the server to deploy operator
+              pattern: ^\bv?(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(-(0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(\.(0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*)?(\+[0-9a-zA-Z-]+(\.[0-9a-zA-Z-]+)*)?$
+
+            keywords:
+              type: array
+              description: List of keywords which will be used to discover and categorize app types
+              items:
+                type: string
+
+            maintainers:
+              type: array
+              description: Those responsible for the creation of this specific app type
+              items:
+                type: object
+                description: Information for a single maintainer
+                required:
+                - name
+                - email
+                properties:
+                  name:
+                    type: string
+                    description: Maintainer's name
+                  email:
+                    type: string
+                    description: Maintainer's email address
+                    format: email
+                optionalProperties:
+                  type: string
+                  description: "Any additional key-value metadata you wish to expose about the maintainer, e.g. github: <username>"
+
+            links:
+              type: array
+              description: Interesting links to find more information about the project, such as marketing page, documentation, or github page
+              items:
+                type: object
+                description: A single link to describe one aspect of the project
+                required:
+                - name
+                - url
+                properties:
+                  name:
+                    type: string
+                    description: Name of the link type, e.g. homepage or github url
+                  url:
+                    type: string
+                    description: URL to which the link should point
+                    format: uri
+
+            icon:
+              type: array
+              description: Icon which should be rendered with the application information
+              items:
+                type: object
+                required:
+                - base64data
+                - mediatype
+                properties:
+                  base64data:
+                    type: string
+                    description: Base64 binary representation of the icon image
+                  mediatype:
+                    type: string
+                    description: Mediatype for the binary data specified in the base64data property
+                    enum:
+                    - image/gif
+                    - image/jpeg
+                    - image/png
+                    - image/svg+xml
+            version:
+              type: string
+              description: Version string, recommended that users use semantic versioning
+              pattern: ^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(-(0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(\.(0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*)?(\+[0-9a-zA-Z-]+(\.[0-9a-zA-Z-]+)*)?$
+
+            replaces:
+              type: string
+              description: Name of the ClusterServiceVersion custom resource that this version replaces
+
+            maturity:
+              type: string
+              description: What level of maturity the software has achieved at this version
+              enum:
+              - planning
+              - pre-alpha
+              - alpha
+              - beta
+              - stable
+              - mature
+              - inactive
+              - deprecated
+            labels:
+              type: object
+              description: Labels that will be applied to associated resources created by the operator.
+            selector:
+              type: object
+              description: Label selector to find resources associated with or managed by the operator
+              properties:
+                matchLabels:
+                  type: object
+                  description: Label key:value pairs to match directly
+                matchExpressions:
+                  type: array
+                  description: A set of expressions to match against the resource.
+                  items:
+                    allOf:
+                      - type: object
+                        required:
+                        - key
+                        - operator
+                        - values
+                        properties:
+                          key:
+                            type: string
+                            description: the key to match
+                          operator:
+                            type: string
+                            description: the operator for the expression
+                            enum:
+                            - In
+                            - NotIn
+                            - Exists
+                            - DoesNotExist
+                          values:
+                            type: array
+                            description: set of values for the expression
+            nativeAPIs:
+              type: array
+              description: What resources are required by the Operator, but must be provided by the underlying cluster and not as an extension.
+              items:
+                type: object
+                required:
+                - group
+                - version
+                - kind
+                properties:
+                  group:
+                    type: string
+                    description: Group of the API resource
+                  version:
+                    type: string
+                    description: Version of the API resource
+                  kind:
+                    type: string
+                    description: Kind of the API resource
+            apiservicedefinitions:
+              type: object
+              properties:
+                owned:
+                  type: array
+                  description: What resources this operator is responsible for managing. No two running operators should manage the same resource.
+                  items:
+                    type: object
+                    required:
+                    - group
+                    - version
+                    - kind
+                    - name
+                    - deploymentName
+                    - displayName
+                    - description
+                    properties:
+                      group:
+                        type: string
+                        description: Group of the APIService (e.g. app.coreos.com)
+                      name:
+                        type: string
+                        description: The plural name for the APIService provided
+                      version:
+                        type: string
+                        description: The version field of the APIService
+                      kind:
+                        type: string
+                        description: The kind field of the APIService
+                      deploymentName:
+                        type: string
+                        description: Name of the extension api-server's deployment
+                      containerPort:
+                        type: number
+                        description: Port where the extension api-server serves TLS traffic
+                      displayName:
+                        type: string
+                        description: A human-readable name for the APIService.
+                      description:
+                        type: string
+                        description: A description of the APIService
+                      resources:
+                        type: array
+                        items:
+                          type: object
+                          description: A list of resources that should be displayed for the APIService
+                          required:
+                          - kind
+                          - version
+                          properties:
+                            name:
+                              type: string
+                              description: If a APIService, the fully qualified name of the APIService (e.g. my-resource-v1.app.coreos.com)
+                            version:
+                              type: string
+                              description: The version of the resource kind
+                            kind:
+                              type: string
+                              description: The kind field of the resource kind
+                      statusDescriptors:
+                        type: array
+                        items:
+                          type: object
+                          description: A spec for a field in the status block of the API resource
+                          required:
+                          - path
+                          - displayName
+                          - description
+                          properties:
+                            path:
+                              type: string
+                              description: A jsonpath indexing into the status object on the API resource where the the status value can be found.
+                            displayName:
+                              type: string
+                              description: A human-readable name for the status entry.
+                            description:
+                              type: string
+                              description: A description of the status entry.
+                            x-descriptors:
+                              type: array
+                              description: A list of descriptors for the status entry that indicate the meaning of the field.
+                              items:
+                                type: string
+                            value:
+                              description: If present, the value of this status is the same for all instances of the API resource and can be found here instead of on the API resource.
+                      specDescriptors:
+                        type: array
+                        items:
+                          type: object
+                          description: A spec for a field in the spec block of the APIService resource.
+                          required:
+                          - path
+                          - displayName
+                          - description
+                          properties:
+                            path:
+                              type: string
+                              description: A jsonpath indexing into the spec object on the API resource where the the spec value can be found.
+                            displayName:
+                              type: string
+                              description: A human-readable name for the spec entry.
+                            description:
+                              type: string
+                              description: A description of the spec entry.
+                            x-descriptors:
+                              type: array
+                              description: A list of descriptors for the spec entry that indicate the meaning of the field.
+                              items:
+                                type: string
+                            value:
+                              description: If present, the value of this spec is the same for all instances of the API Resource and can be found here instead of on the API resource.
+                      actionDescriptors:
+                        type: array
+                        items:
+                          type: object
+                          description: A spec for actions that can be performed on instances of the API resource
+                          required:
+                          - path
+                          - displayName
+                          - description
+                          properties:
+                            path:
+                              type: string
+                              description: A jsonpath indexing into the spec object on the API resource where the the spec value can be found.
+                            displayName:
+                              type: string
+                              description: A human-readable name for the action.
+                            description:
+                              type: string
+                              description: A description of the action.
+                            x-descriptors:
+                              type: array
+                              description: A list of descriptors for the action that indicate the meaning of the action.
+                              items:
+                                type: string
+                            value:
+                              description: If present, the value of this action is the same for all instances of the API resource and can be found here instead of on the API resource.
+                required:
+                  type: array
+                  description: What resources this operator is responsible for managing. No two running operators should manage the same resource.
+                  items:
+                    type: object
+                    required:
+                    - group
+                    - version
+                    - kind
+                    - name
+                    - displayName
+                    - description
+                    properties:
+                      group:
+                        type: string
+                        description: Group of the APIService (e.g. app.coreos.com)
+                      version:
+                        type: string
+                        description: The version field of the APIService
+                      kind:
+                        type: string
+                        description: The kind field of the APIService
+                      name:
+                        type: string
+                        description: The plural name for the APIService provided
+                      deploymentName:
+                        type: string
+                        description: Name of the extension api-server's deployment
+                      containerPort:
+                        type: number
+                        description: Port where the extension api-server serves TLS traffic
+                      displayName:
+                        type: string
+                        description: A human-readable name for the APIService.
+                      description:
+                        type: string
+                        description: A description of the APIService
+                      statusDescriptors:
+                        type: array
+                        items:
+                          type: object
+                          description: A spec for a field in the status block of the APIService
+                          required:
+                          - path
+                          - displayName
+                          - description
+                          properties:
+                            path:
+                              type: string
+                              description: A jsonpath indexing into the status object on the API Resource where the the status value can be found.
+                            displayName:
+                              type: string
+                              description: A human-readable name for the status entry.
+                            description:
+                              type: string
+                              description: A description of the status entry.
+                            x-descriptors:
+                              type: array
+                              description: A list of descriptors for the status entry that indicate the meaning of the field.
+                              items:
+                                type: string
+                            value:
+                              description: If present, the value of this status is the same for all instances of the API Resource and can be found here instead of on the API Resource.
+
+            customresourcedefinitions:
+              type: object
+              properties:
+                owned:
+                  type: array
+                  description: What resources this operator is responsible for managing. No two running operators should manage the same resource.
+                  items:
+                    type: object
+                    required:
+                      - name
+                      - version
+                      - kind
+                      - displayName
+                      - description
+                    properties:
+                      name:
+                        type: string
+                        description: Fully qualified name of the CustomResourceDefinition (e.g. my-resource-v1.app.coreos.com)
+                      version:
+                        type: string
+                        description: The version field of the CustomResourceDefinition
+                      kind:
+                        type: string
+                        description: The kind field of the CustomResourceDefinition
+                      displayName:
+                        type: string
+                        description: A human-readable name for the CRD.
+                      description:
+                        type: string
+                        description: A description of the CRD
+                      resources:
+                        type: array
+                        items:
+                          type: object
+                          description: A list of resources that should be displayed for the CRD
+                          required:
+                            - kind
+                            - version
+                          properties:
+                            name:
+                              type: string
+                              description: If a CRD, the fully qualified name of the CustomResourceDefinition (e.g. my-resource-v1.app.coreos.com)
+                            version:
+                              type: string
+                              description: The version of the resource kind
+                            kind:
+                              type: string
+                              description: The kind field of the resource kind
+                      statusDescriptors:
+                        type: array
+                        items:
+                          type: object
+                          description: A spec for a field in the status block of the CRD
+                          required:
+                            - path
+                            - displayName
+                            - description
+                          properties:
+                            path:
+                              type: string
+                              description: A jsonpath indexing into the status object on the CR where the the status value can be found.
+                            displayName:
+                              type: string
+                              description: A human-readable name for the status entry.
+                            description:
+                              type: string
+                              description: A description of the status entry.
+                            x-descriptors:
+                              type: array
+                              description: A list of descriptors for the status entry that indicate the meaning of the field.
+                              items:
+                                type: string
+                            value:
+                              description: If present, the value of this status is the same for all instances of the CRD and can be found here instead of on the CR.
+                      specDescriptors:
+                        type: array
+                        items:
+                          type: object
+                          description: A spec for a field in the spec block of the CRD
+                          required:
+                            - path
+                            - displayName
+                            - description
+                          properties:
+                            path:
+                              type: string
+                              description: A jsonpath indexing into the spec object on the CR where the the spec value can be found.
+                            displayName:
+                              type: string
+                              description: A human-readable name for the spec entry.
+                            description:
+                              type: string
+                              description: A description of the spec entry.
+                            x-descriptors:
+                              type: array
+                              description: A list of descriptors for the spec entry that indicate the meaning of the field.
+                              items:
+                                type: string
+                            value:
+                              description: If present, the value of this spec is the same for all instances of the CRD and can be found here instead of on the CR.
+                      actionDescriptors:
+                        type: array
+                        items:
+                          type: object
+                          description: A spec for actions that can be performed on instances of the CRD
+                          required:
+                            - path
+                            - displayName
+                            - description
+                          properties:
+                            path:
+                              type: string
+                              description: A jsonpath indexing into the spec object on the CR where the the spec value can be found.
+                            displayName:
+                              type: string
+                              description: A human-readable name for the action.
+                            description:
+                              type: string
+                              description: A description of the action.
+                            x-descriptors:
+                              type: array
+                              description: A list of descriptors for the action that indicate the meaning of the action.
+                              items:
+                                type: string
+                            value:
+                              description: If present, the value of this action is the same for all instances of the CRD and can be found here instead of on the CR.
+                required:
+                  type: array
+                  description: What resources this operator is responsible for managing. No two running operators should manage the same resource.
+                  items:
+                    type: object
+                    required:
+                      - name
+                      - version
+                      - kind
+                      - displayName
+                      - description
+                    properties:
+                      name:
+                        type: string
+                        description: Fully qualified name of the CustomResourceDefinition (e.g. my-resource-v1.app.coreos.com)
+                      version:
+                        type: string
+                        description: The version field of the CustomResourceDefinition
+                      kind:
+                        type: string
+                        description: The kind field of the CustomResourceDefinition
+                      displayName:
+                        type: string
+                        description: A human-readable name for the CRD.
+                      description:
+                        type: string
+                        description: A description of the CRD
+                      statusDescriptors:
+                        type: array
+                        items:
+                          type: object
+                          description: A spec for a field in the status block of the CRD
+                          required:
+                            - path
+                            - displayName
+                            - description
+                          properties:
+                            path:
+                              type: string
+                              description: A jsonpath indexing into the status object on the CR where the the status value can be found.
+                            displayName:
+                              type: string
+                              description: A human-readable name for the status entry.
+                            description:
+                              type: string
+                              description: A description of the status entry.
+                            x-descriptors:
+                              type: array
+                              description: A list of descriptors for the status entry that indicate the meaning of the field.
+                              items:
+                                type: string
+                            value:
+                              description: If present, the value of this status is the same for all instances of the CRD and can be found here instead of on the CR.
+
+
+            install:
+              type: object
+              description: Information required to install this specific version of the operator software
+              oneOf:
+              - type: object
+                required:
+                - strategy
+                - spec
+                properties:
+                  strategy:
+                    type: string
+                    enum: ['image']
+                  spec:
+                    type: object
+                    required:
+                    - image
+                    properties:
+                      image:
+                        type: string
+              - type: object
+                required:
+                - strategy
+                - spec
+                properties:
+                  strategy:
+                    type: string
+                    enum: ['deployment']
+                  spec:
+                    type: object
+                    required:
+                    - deployments
+                    properties:
+                      installModes:
+                        type: array
+                        description: List of supported install modes for the operator
+                        items:
+                          type: object
+                          description: A tuple representing a mode of installation and whether the operator supports it
+                          required:
+                            - type
+                            - supported
+                          properties:
+                            type:
+                              type: string
+                              description: A type of install mode
+                              enum:
+                                - OwnNamespace
+                                - SingleNamespace
+                                - MultiNamespace
+                                - AllNamespaces
+                            supported:
+                              type: boolean
+                              description: Represents if the install mode type is supported
+                      deployments:
+                        type: array
+                        description: List of deployments to create
+                        items:
+                          type: object
+                          description: A name and deployment to create in the cluster
+                          required:
+                            - name
+                            - spec
+                          properties:
+                            name:
+                              type: string
+                              description: the consistent name of the deployment
+                            spec:
+                              type: object
+                              description: The deployment spec to create in the cluster
+                      permissions:
+                        type: array
+                        description: Permissions needed by the deployement to run correctly
+                        items:
+                          type: object
+                          required:
+                            - serviceAccountName
+                            - rules
+                          properties:
+                            serviceAccountName:
+                              type: string
+                              description: The service account name to create for the deployment
+                            rules:
+                              type: array
+                              items:
+                                type: object
+                                description: a rule required by the service account
+                                properties:
+                                  apiGroups:
+                                    type: array
+                                    description: apiGroups the rule applies to
+                                    items:
+                                      type: string
+                                  resources:
+                                    type: array
+                                    items:
+                                      type: string
+                                  resourceNames:
+                                    type: array
+                                    items:
+                                      type: string
+                                  verbs:
+                                    type: array
+                                    items:
+                                      type: string
+                                      enum:
+                                        - "*"
+                                        - assign
+                                        - get
+                                        - list
+                                        - watch
+                                        - create
+                                        - update
+                                        - patch
+                                        - delete
+                                        - deletecollection
+                                        - initialize
+                                        - use
+                      clusterPermissions:
+                        type: array
+                        description: Cluster permissions needed by the deployement to run correctly
+                        items:
+                          type: object
+                          required:
+                          - serviceAccountName
+                          - rules
+                          properties:
+                            serviceAccountName:
+                              type: string
+                              description: The service account name to create for the deployment
+                            rules:
+                              type: array
+                              items:
+                                type: object
+                                required:
+                                - verbs
+                                description: a rule required by the service account
+                                properties:
+                                  apiGroups:
+                                    type: array
+                                    description: apiGroups the rule applies to
+                                    items:
+                                      type: string
+                                  resources:
+                                    type: array
+                                    items:
+                                      type: string
+                                  resourceNames:
+                                    type: array
+                                    items:
+                                      type: string
+                                  nonResourceURLs:
+                                    type: array
+                                    items:
+                                      type: string
+                                  verbs:
+                                    type: array
+                                    items:
+                                      type: string
+                                      enum:
+                                      - "*"
+                                      - assign
+                                      - get
+                                      - list
+                                      - watch
+                                      - create
+                                      - update
+                                      - patch
+                                      - put
+                                      - post
+                                      - delete
+                                      - deletecollection
+                                      - initialize
+                                      - use
+        status:
+          type: object
+          description: Status for a ClusterServiceVersion
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: installplans.operators.coreos.com
+  annotations:
+    displayName: Install Plan
+    description: Represents a plan to install and resolve dependencies for Cluster Services
+spec:
+  group: operators.coreos.com
+  version: v1alpha1
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true
+  scope: Namespaced
+  names:
+    plural: installplans
+    singular: installplan
+    kind: InstallPlan
+    listKind: InstallPlanList
+    shortNames:
+    - ip
+    categories:
+    - olm
+  additionalPrinterColumns:
+  - name: CSV
+    type: string
+    description: The first CSV in the list of clusterServiceVersionNames
+    JSONPath: .spec.clusterServiceVersionNames[0]
+  - name: Source
+    type: string
+    description: The catalog source for the specified CSVs.
+    JSONPath: .spec.source
+  - name: Approval
+    type: string
+    description: The approval mode
+    JSONPath: .spec.approval
+  - name: Approved
+    type: boolean
+    JSONPath: .spec.approved
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      properties:
+        spec:
+          type: object
+          description: Spec for an InstallPlan
+          required:
+          - clusterServiceVersionNames
+          - approval
+          properties:
+            source:
+              type: string
+              description: Name of the preferred CatalogSource
+            sourceNamespace:
+              type: string
+              description: Namespace that contains the preffered CatalogSource
+            clusterServiceVersionNames:
+              type: array
+              description: A list of the names of the Cluster Services
+              items:
+                type: string
+          anyOf:
+            - properties:
+                approval:
+                  enum:
+                    - Manual
+                approved:
+                  type: boolean
+              required:
+                - approved
+            - properties:
+                approval:
+                  enum:
+                    - Automatic
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: subscriptions.operators.coreos.com
+  annotations:
+    displayName: Subscription
+    description: Subcribes service catalog to a source and channel to recieve updates for packages.
+spec:
+  group: operators.coreos.com
+  version: v1alpha1
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true
+  scope: Namespaced
+  names:
+    plural: subscriptions
+    singular: subscription
+    kind: Subscription
+    listKind: SubscriptionList
+    shortNames:
+    - sub
+    - subs
+    categories:
+    - olm
+  additionalPrinterColumns:
+  - name: Package
+    type: string
+    description: The package subscribed to
+    JSONPath: .spec.name
+  - name: Source
+    type: string
+    description: The catalog source for the specified package
+    JSONPath: .spec.source
+  - name: Channel
+    type: string
+    description: The channel of updates to subscribe to
+    JSONPath: .spec.channel
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      properties:
+        spec:
+          type: object
+          description: Spec for a Subscription
+          required:
+          - source
+          - name
+          properties:
+            source:
+              type: string
+              description: Name of a CatalogSource that defines where and how to find the channel
+            sourceNamespace:
+              type: string
+              description: The Kubernetes namespace where the CatalogSource used is located
+            name:
+              type: string
+              description: Name of the package that defines the application
+            channel:
+              type: string
+              description: Name of the channel to track
+            startingCSV:
+              type: string
+              description: Name of the AppType that this subscription tracks
+            installPlanApproval:
+              type: string
+              description: Approval mode for emitted InstallPlans
+              enum:
+              - Manual
+              - Automatic
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: catalogsources.operators.coreos.com
+  annotations:
+    displayName: CatalogSource
+    description: A source configured to find packages and updates.
+spec:
+  group: operators.coreos.com
+  version: v1alpha1
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true
+  scope: Namespaced
+  names:
+    plural: catalogsources
+    singular: catalogsource
+    kind: CatalogSource
+    listKind: CatalogSourceList
+    shortNames:
+    - catsrc
+    categories:
+    - olm
+  additionalPrinterColumns:
+  - name: Name
+    type: string
+    description: The pretty name of the catalog
+    JSONPath: .spec.displayName
+  - name: Type
+    type: string
+    description: The type of the catalog
+    JSONPath: .spec.sourceType
+  - name: Publisher
+    type: string
+    description: The publisher of the catalog
+    JSONPath: .spec.publisher
+  - name: Age
+    type: date
+    JSONPath: .metadata.creationTimestamp
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      properties:
+        spec:
+          type: object
+          description: Spec for a catalog source.
+          required:
+          - sourceType
+          properties:
+            sourceType:
+              type: string
+              description: The type of the source. `configmap` is the new name for `internal`
+              enum:
+              - internal   # deprecated
+              - configmap
+              - grpc
+
+            configMap:
+              type: string
+              description: The name of a ConfigMap that holds the entries for an in-memory catalog.
+
+            address:
+              type: string
+              description: An optional address. When set, directs OLM to connect to use a pre-existing registry server at this address.
+
+            image:
+              type: string
+              description: An image that serves a grpc registry. Only valid for `grpc` sourceType. If both image and address are set, OLM does not use the address field.
+
+            displayName:
+              type: string
+              description: Pretty name for display
+
+            publisher:
+              type: string
+              description: The name of an entity that publishes this catalog
+
+            secrets:
+              type: array
+              description: A set of secrets that can be used to access the contents of the catalog. It is best to keep this list small, since each will need to be tried for every catalog entry.
+              items:
+                type: string
+                description: A name of a secret in the namespace where the CatalogSource is defined.
+        status:
+          type: object
+          description: The status of the CatalogSource
+          properties:
+            configMapReference:
+              type: object
+              description: If sourceType is `internal` or `configmap`, then this holds a reference to the configmap associated with this CatalogSource.
+              properties:
+                name:
+                  type: string
+                  description: name of the configmap
+                namespace:
+                  type: string
+                  description: namespace of the configmap
+                resourceVersion:
+                  type: string
+                  description: resourceVersion of the configmap
+                uid:
+                  type: string
+                  description: uid of the configmap
+            registryService:
+              type: object
+              properties:
+                protocol:
+                  type: string
+                  description: protocol of the registry service
+                  enum:
+                    - grpc
+                serviceName:
+                  type: string
+                  description: name of the registry service
+                serviceNamespace:
+                  type: string
+                  description: namespace of the registry service
+                port:
+                  type: string
+                  description: port of the registry service
+            lastSync:
+                type: string
+                description: the last time the catalog was updated. If this time is less than the last updated time on the object, the catalog will be re-cached.
+
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: olm-operator
+  namespace: olm
+  labels:
+    app: olm-operator
+spec:
+  strategy:
+    type: RollingUpdate
+  replicas: 1
+  selector:
+    matchLabels:
+      app: olm-operator
+  template:
+    metadata:
+      labels:
+        app: olm-operator
+    spec:
+      serviceAccountName: olm-operator-serviceaccount
+      containers:
+        - name: olm-operator
+          command:
+          - /bin/olm
+          args:
+          - -writeStatusName
+          - ""
+          image: quay.io/operator-framework/olm@sha256:7e4b13b89b3d59876b228697bbd0c9e364fd73f946ab90308c34fd82053a5a76
+          imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: 8080
+            - containerPort: 8081
+              name: metrics
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: 8080
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: 8080
+          env:
+        
+          - name: OPERATOR_NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
+          - name: OPERATOR_NAME
+            value: olm-operator
+          
+      
+      nodeSelector:
+        beta.kubernetes.io/os: linux
+        
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: catalog-operator
+  namespace: olm
+  labels:
+    app: catalog-operator
+spec:
+  strategy:
+    type: RollingUpdate
+  replicas: 1
+  selector:
+    matchLabels:
+      app: catalog-operator
+  template:
+    metadata:
+      labels:
+        app: catalog-operator
+    spec:
+      serviceAccountName: olm-operator-serviceaccount
+      containers:
+        - name: catalog-operator
+          command:
+          - /bin/catalog
+          args:
+          - '-namespace'
+          - olm
+          - -configmapServerImage=quay.io/operator-framework/configmap-operator-registry:latest
+          image: quay.io/operator-framework/olm@sha256:7e4b13b89b3d59876b228697bbd0c9e364fd73f946ab90308c34fd82053a5a76
+          imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: 8080
+            - containerPort: 8081
+              name: metrics
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: 8080
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: 8080
+          env:
+          
+          
+      
+      nodeSelector:
+        beta.kubernetes.io/os: linux
+        
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: aggregate-olm-edit
+  labels:
+    rbac.authorization.k8s.io/aggregate-to-admin: "true"
+    rbac.authorization.k8s.io/aggregate-to-edit: "true"
+rules:
+- apiGroups: ["operators.coreos.com"]
+  resources: ["clusterserviceversions", "catalogsources", "installplans", "subscriptions", "packagemanifests"]
+  verbs: ["create", "update", "patch", "delete"]
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: aggregate-olm-view
+  labels:
+    rbac.authorization.k8s.io/aggregate-to-admin: "true"
+    rbac.authorization.k8s.io/aggregate-to-edit: "true"
+    rbac.authorization.k8s.io/aggregate-to-view: "true"
+rules:
+- apiGroups: ["operators.coreos.com"]
+  resources: ["clusterserviceversions", "catalogsources", "installplans", "subscriptions", "packagemanifests"]
+  verbs: ["get", "list", "watch"]
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: operatorgroups.operators.coreos.com
+spec:
+  group: operators.coreos.com
+  version: v1
+  versions:
+    - name: v1
+      served: true
+      storage: true
+    - name: v1alpha2
+      served: true
+      storage: false
+  names:
+    plural: operatorgroups
+    singular: operatorgroup
+    kind: OperatorGroup
+    listKind: OperatorGroupList
+    shortNames:
+      - og
+    categories:
+      - olm
+  scope: Namespaced
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      properties:
+        spec:
+          properties:
+            selector:
+              type: object
+              description: Optional label selector to find resources associated with or managed by the operator
+              anyOf:
+                - properties:
+                    matchLabels:
+                      type: object
+                      description: Label key:value pairs to match directly
+                  required:
+                    - matchLabels
+                - properties:
+                    matchExpressions:
+                      type: array
+                      description: A set of expressions to match against the resource.
+                      items:
+                        allOf:
+                          - type: object
+                            required:
+                            - key
+                            - operator
+                            - values
+                            properties:
+                              key:
+                                type: string
+                                description: the key to match
+                              operator:
+                                type: string
+                                description: the operator for the expression
+                                enum:
+                                - In
+                                - NotIn
+                                - Exists
+                                - DoesNotExist
+                              values:
+                                type: array
+                                description: set of values for the expression
+                  required:
+                    - matchExpressions
+            targetNamespaces:
+              type: array
+              description: Optional list of target namespaces. If set, OLM will ignore selector.
+              items:
+                type: string
+                pattern: ^\S+$
+            serviceAccountName:
+              type: string
+            staticProvidedAPIs:
+              type: boolean
+              description: If true, OLM will not modify the OperatorGroup's providedAPIs annotation.
+          type: object
+        status:
+          properties:
+            lastUpdated:
+              format: date-time
+              type: string
+            namespaces:
+              items:
+                type: string
+              type: array
+          required:
+          - namespaces
+          - lastUpdated
+          type: object
+      required:
+      - metadata
+---
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: olm-operators
+  namespace: olm
+data:
+  customResourceDefinitions: |-
+  clusterServiceVersions: |-
+    - apiVersion: operators.coreos.com/v1alpha1
+      kind: ClusterServiceVersion
+      metadata:
+        name: packageserver.v0.9.0
+        namespace: olm
+      spec:
+        displayName: Package Server
+        description: Represents an Operator package that is available from a given CatalogSource which will resolve to a ClusterServiceVersion.
+        minKubeVersion: 1.11.0
+        keywords: ['packagemanifests', 'olm', 'packages']
+        maintainers:
+        - name: Red Hat
+          email: openshift-operators@redhat.com
+        provider:
+          name: Red Hat
+        links:
+        - name: Package Server
+          url: https://github.com/operator-framework/operator-lifecycle-manager/tree/master/pkg/package-server
+        installModes:
+        - type: OwnNamespace
+          supported: true
+        - type: SingleNamespace
+          supported: true
+        - type: MultiNamespace
+          supported: true
+        - type: AllNamespaces
+          supported: true
+        install:
+          strategy: deployment
+          spec:
+            clusterPermissions:
+            - serviceAccountName: packageserver
+              rules:
+              - apiGroups:
+                  - authorization.k8s.io
+                resources:
+                  - subjectaccessreviews
+                verbs:
+                  - create
+                  - get
+              - apiGroups:
+                - ""
+                resources:
+                - configmaps
+                verbs:
+                - get
+                - list
+                - watch
+              - apiGroups:
+                - "operators.coreos.com"
+                resources:
+                - catalogsources
+                verbs:
+                - get
+                - list
+                - watch
+              - apiGroups:
+                - "packages.operators.coreos.com"
+                resources:
+                - packagemanifests
+                verbs:
+                - get
+                - list
+            deployments:
+            - name: packageserver
+              spec:
+                strategy:
+                  type: RollingUpdate
+                replicas: 2
+                selector:
+                  matchLabels:
+                    app: packageserver
+                template:
+                  metadata:
+                    labels:
+                      app: packageserver
+                  spec:
+                    serviceAccountName: packageserver
+                    nodeSelector:
+                      beta.kubernetes.io/os: linux
+                      
+                    containers:
+                    - name: packageserver
+                      command:
+                      - /bin/package-server
+                      - -v=4
+                      - --secure-port
+                      - "5443"
+                      - --global-namespace
+                      - olm
+                      image: quay.io/operator-framework/olm@sha256:7e4b13b89b3d59876b228697bbd0c9e364fd73f946ab90308c34fd82053a5a76
+                      imagePullPolicy: Always
+                      ports:
+                      - containerPort: 5443
+                      livenessProbe:
+                        httpGet:
+                          scheme: HTTPS
+                          path: /healthz
+                          port: 5443
+                      readinessProbe:
+                        httpGet:
+                          scheme: HTTPS
+                          path: /healthz
+                          port: 5443
+        maturity: alpha
+        version: 0.9.0
+        apiservicedefinitions:
+          owned:
+          - group: packages.operators.coreos.com
+            version: v1
+            kind: PackageManifest
+            name: packagemanifests
+            displayName: PackageManifest
+            description: A PackageManifest is a resource generated from existing CatalogSources and their ConfigMaps
+            deploymentName: packageserver
+            containerPort: 5443
+  packages: |-
+    - packageName: packageserver
+      channels:
+      - name: alpha
+        currentCSV: packageserver.v0.9.0

--- a/olm/02-olm.yaml
+++ b/olm/02-olm.yaml
@@ -1,0 +1,48 @@
+---
+apiVersion: operators.coreos.com/v1alpha1
+kind: CatalogSource
+metadata:
+  name: olm-operators
+  namespace: olm
+spec:
+  sourceType: internal
+  configMap: olm-operators
+  displayName: OLM Operators
+  publisher: Red Hat
+---
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: global-operators
+  namespace: operators
+---
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: olm-operators
+  namespace: olm
+spec:
+  targetNamespaces:
+    - olm
+---
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: packageserver
+  namespace: olm
+spec:
+  source: olm-operators
+  sourceNamespace: olm
+  name: packageserver
+  channel: alpha
+---
+apiVersion: operators.coreos.com/v1alpha1
+kind: CatalogSource
+metadata:
+  name: operatorhubio-catalog
+  namespace: olm
+spec:
+  sourceType: grpc
+  image: quay.io/operator-framework/upstream-community-operators:latest
+  displayName: Community Operators
+  publisher: OperatorHub.io

--- a/olm/kubefed.yaml
+++ b/olm/kubefed.yaml
@@ -1,0 +1,24 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: test-namespace
+---
+apiVersion: operators.coreos.com/v1alpha2
+kind: OperatorGroup
+metadata:
+  name: operatorgroup
+  namespace: test-namespace
+spec:
+  targetNamespaces:
+  - test-namespace
+---
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: test-namespace
+  namespace: test-namespace
+spec:
+  channel: alpha
+  name: federation
+  source: operatorhubio-catalog
+  sourceNamespace: olm


### PR DESCRIPTION
#Removed federation-v2 submodule

Now we're using the operator deployment from OLM, the submodule is not needed anymore

#Updated instructions to work with kubefed v0.0.10

Updated base docs with latest instructions from kubefed upstream repository