### PR TITLE
Small updates

### DIFF
--- a/labs/2.md
+++ b/labs/2.md
@@ -1,6 +1,3 @@
-
-
-
 <a id="markdown-create-the-two-openshift-clusters" name="create-the-two-openshift-clusters"></a>
 ## Create the two OpenShift clusters
 

--- a/labs/3.md
+++ b/labs/3.md
@@ -1,48 +1,51 @@
-<a id="markdown-deploy-federation" name="deploy-federation"></a>
-## Deploy Federation
+<a id="markdown-deploy-federation" name="deploy-namespace-scoped-federation"></a>
+## Deploy Namespace Scoped Federation
 
 Federation target clusters do not require federation to be installed on them at
-all, but for convenience, we will use one of the clusters (`cluster1`) to host
-the federation control plane.
+all, but for convenience, we are using one of the clusters (`cluster1`) to host
+the KubeFed control plane.
 
-At the moment, the Federation Operator only works in namespace-scoped mode, in the future cluster-scoped mode will be supported as well by the operator.
-
-In order to deploy the operator, we are going to use `Operator Hub` within the OCP4 WebUI.
-
-1. Login into `cluster1` web console as `kubeadmin` user
-   1. Login details were reported by the installer
-2. Create the namespace to be federated
-   1. On the left panel click `Home -> Projects`
-   2. Click `Create Project`
-   3. Name it `test-namespace`
-   4. Click `Create`
-3. Install Federation from `Operator Hub`
-   1. On the left panel click `Catalog -> Operator Hub`
-   2. Select `Federation` from operator list
-   3. If a warning about use of Community Operators is shown click `Continue`
-   4. Click `Install`
-   5. Make sure `test-namespace` is selected as destination namespace
-   6. Click `Subscribe`
-4. Check the Operator Subscription status
-   1. On the left panel click `Catalog -> Operator Management`
-   2. Click `Operator Subscriptions` tab
-   3. Ensure the `Status` is "Up to date" for the `federation` subscription
-
-If everything is okay, we should have the federation controller running in the namespace  `test-namespace`.
+You should see the KubeFed Operator running in the namespace `mongo`
 
 ~~~sh
-oc --context=cluster1 -n test-namespace get pods
+oc --context=cluster1 -n mongo get pods
 
 NAME                                             READY     STATUS    RESTARTS   AGE
-federation-controller-manager-744f57ccff-q4f6k  1/1       Running   0          3m18s
+kubefed-operator-5c5d57484d-tvrcb                1/1       Running   0          3m18s
+~~~
+
+Now we need to create a KubeFed resource to instantiate the KubeFed Controller in `cluster` scoped mode:
+
+~~~sh
+cat <<-EOF | oc apply -n mongo -f -
+---
+apiVersion: operator.kubefed.io/v1alpha1
+kind: KubeFed
+metadata:
+  name: kubefed-resource
+spec: 
+  scope: Namespaced
+---
+EOF
+~~~
+
+The KubeFed Controller should be deployed now:
+
+~~~sh
+oc --context=cluster1 -n mongo get pods
+
+NAME                                             READY     STATUS    RESTARTS   AGE
+kubefed-operator-5c5d57484d-tvrcb                1/1       Running   0          3m18s
+kubefed-controller-manager-7dfcffb798-flbcm      1/1       Running   0          30s
+kubefed-controller-manager-7dfcffb798-vzcwg      1/1       Running   0          31s
 ~~~
 
 Now we are going to enable some of the federated types needed for our demo application
 
 ~~~sh
-for type in namespaces secrets serviceaccounts services configmaps deployments.apps
+for type in namespaces secrets services deployments.apps persistentvolumeclaim
 do
-    kubefedctl enable $type --federation-namespace test-namespace
+    kubefedctl enable $type --kubefed-namespace mongo
 done
 ~~~
 
@@ -53,100 +56,43 @@ Verify that there are no clusters yet (but note
 that you can already reference the CRDs for federated clusters):
 
 ~~~sh
-oc get federatedclusters -n test-namespace
+oc get kubefedclusters -n mongo
 
 No resources found.
 ~~~
 
-Now use the `kubefedctl` tool to register (*join*) the two clusters:
+Now use the `kubefedctl` tool to register (*join*) the three clusters:
 
 ~~~sh
 kubefedctl join cluster1 \
             --host-cluster-context cluster1 \
             --cluster-context cluster1 \
-            --add-to-registry \
             --v=2 \
-            --federation-namespace=test-namespace
+            --kubefed-namespace=mongo
 kubefedctl join cluster2 \
             --host-cluster-context cluster1 \
             --cluster-context cluster2 \
-            --add-to-registry \
             --v=2 \
-            --federation-namespace=test-namespace
+            --kubefed-namespace=mongo
+kubefedctl join cluster3 \
+            --host-cluster-context cluster1 \
+            --cluster-context cluster3 \
+            --v=2 \
+            --kubefed-namespace=mongo
 ~~~
 
-Note that the names of the clusters (`cluster1` and `cluster2`) in the commands above are a reference to the contexts configured in the `oc` client. For this process to work as expected you need to make sure that the [client contexts](#configure-client-context-for-cluster-admin-access) have been properly configured with the right access levels and context names. The `--cluster-context` option for `kubefedctl join` can be used to override the reference to the client context configuration. When the option is not present, `kubefedctl` uses the cluster name to identify the client context.
+Note that the names of the clusters (`cluster1`, `cluster2` and `cluster3`) in the commands above are a reference to the contexts configured in the `oc` client. For this process to work as expected you need to make sure that the [client contexts](./2.md#configure-client-context-for-cluster-admin-access) have been properly configured with the right access levels and context names. The `--cluster-context` option for `kubefedctl join` can be used to override the reference to the client context configuration. When the option is not present, `kubefedctl` uses the cluster name to identify the client context.
 
 Verify that the federated clusters are registered and in a ready state (this
 can take a moment):
 
 ~~~sh
-oc describe federatedclusters -n test-namespace
+oc get kubefedclusters -n mongo
 
-Name:         cluster1
-Namespace:    test-namespace
-Labels:       <none>
-Annotations:  <none>
-API Version:  core.federation.k8s.io/v1alpha1
-Kind:         FederatedCluster
-Metadata:
-  Creation Timestamp:  2019-05-15T10:48:39Z
-  Generation:          1
-  Resource Version:    236828
-  Self Link:           /apis/core.federation.k8s.io/v1alpha1/namespaces/test-namespace/federatedclusters/cluster1
-  UID:                 ff6a7223-76fe-11e9-89e9-02fb71b1e13a
-Spec:
-  Cluster Ref:
-    Name:  cluster1
-  Secret Ref:
-    Name:  cluster1-kx98r
-Status:
-  Conditions:
-    Last Probe Time:       2019-05-15T10:50:52Z
-    Last Transition Time:  2019-05-15T10:48:41Z
-    Message:               /healthz responded with ok
-    Reason:                ClusterReady
-    Status:                True
-    Type:                  Ready
-  Region:                  us-east-1
-  Zones:
-    us-east-1a
-    us-east-1b
-    us-east-1c
-Events:  <none>
-
-
-Name:         cluster2
-Namespace:    test-namespace
-Labels:       <none>
-Annotations:  <none>
-API Version:  core.federation.k8s.io/v1alpha1
-Kind:         FederatedCluster
-Metadata:
-  Creation Timestamp:  2019-05-15T10:49:35Z
-  Generation:          1
-  Resource Version:    236829
-  Self Link:           /apis/core.federation.k8s.io/v1alpha1/namespaces/test-namespace/federatedclusters/cluster2
-  UID:                 211ba702-76ff-11e9-a071-12235e364a80
-Spec:
-  Cluster Ref:
-    Name:  cluster2
-  Secret Ref:
-    Name:  cluster2-6dr6x
-Status:
-  Conditions:
-    Last Probe Time:       2019-05-15T10:50:52Z
-    Last Transition Time:  2019-05-15T10:49:41Z
-    Message:               /healthz responded with ok
-    Reason:                ClusterReady
-    Status:                True
-    Type:                  Ready
-  Region:                  us-east-2
-  Zones:
-    us-east-2a
-    us-east-2b
-    us-east-2c
-Events:  <none>
+NAME       READY     AGE
+cluster1   True      28s
+cluster2   True      21s
+cluster3   True      23s
 ~~~
 
 Next Lab: [Lab 4 - Example Application One](./4.md)<br>


### PR DESCRIPTION
In the first part of the lab, students will deploy a MongoDB ReplicaSet across multiple clusters using namespace scoped federation. In the second part, Pacman app will be deployed across multiple clusters using cluster scoped federation as the app needs to create cluster scoped objects.

We should use different clusters for hosting namespace scoped and cluster scoped KubeFed controllers. These modifications, instruct the students to deploy the KubeFed namespace scoped controller in the mongo namespace.

The mongo namespace will already exist, the KubeFed operator will be already deployed so we can stick to a specific Operator version.