### PR TITLE
Updates rc6

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,15 +3,15 @@ This repository contains demonstrations, labs, and examples
 of the use of Kubefed and/or the management of multiple OpenShift clusters.
 
 ## What is Federation
-Put quite simply, Federation is the process of connecting one or more Kubernetes clusters. The explanation from OperatorHub states
+Simply, Federation is the process of connecting one or more Kubernetes clusters. The explanation from OperatorHub states,<br>
 ``
 Kubernetes Federation is a tool to sync (aka "federate") a set of Kubernetes objects from a "source" into a set of other clusters. Common use-cases include federating Namespaces across all of your clusters or rolling out an application across several geographically distributed clusters. The Kubernetes Federation Operator runs all of the components under the hood to quickly get up and running with this powerful concept. Federation is a key part of any Hybrid Cloud capability.
-``
+``<br>
 There are two ways to use Kubefed currently: Namespace and Cluster scoped.
 For a breakdown of what this entails, see our [KubeFed Cluster-Scoped Vs Namespace-Scoped](docs/kubefed-scope.md) guide.
 
 ### RHTE lab
-If you are attend Red Hat tech exchange follow the link below will bring you to the first lab.<br>
+If you are attending Red Hat tech exchange, the link below will bring you to the first lab.<br>
 [Red Hat Tech Exchange Lab - Hands on with Red Hat Multi-Cluster Federation: Application Portability](./labs/README.md)<br>
 
 ### Namespace Scoped labs

--- a/docs/kubefed-scope.md
+++ b/docs/kubefed-scope.md
@@ -9,7 +9,7 @@
 
 ### How is the installation different for cluster-scoped KubeFed?
 * We recommend to install the KubeFed Operator in single namespace mode, and use “kube-federation-system” as the namespace to watch as this is the default for the kubefedctl tool.
-* If using the KubeFed Operator, create a KubeFed Custom Resource in the chosen namespace, setting the “spec | scope” to “Cluster”.
+* If using the KubeFed Operator, create KubeFedWebHook and KubeFed Custom Resources in the chosen namespace, setting the “spec | scope” of the latter resource to “Cluster”.
 * Join cluster(s). If KubeFed is installed in the “kube-federation-system” namespace, there is no need to specify --kubefed-namespace parameter.
 * If necessary, enable additional resource types to federate, remembering that any namespaced resource types will also require that the “Namespaces” resource type itself be enabled. You can see a list of existing enabled types by using kubectl or oc to “get” federatedtypeconfigs from the kubefed namespace.
 * Federate any namespaces containing federated resources intended for propagation. 

--- a/docs/ocp4-cluster-scoped.md
+++ b/docs/ocp4-cluster-scoped.md
@@ -160,7 +160,13 @@ namespaces starting with `kube` to be protected.
    1. On the left panel click `Catalog -> Operator Management`.
    2. Click `Operator Subscriptions` tab.
    3. Ensure the `Status` is "Up to date" for the `kubefed-operator` subscription. This process may take a few minutes.
-4. Create a KubeFed resource to instantiate the KubeFed controller.
+4. Create a KubeFedWebHook resource.
+   1. On the left panel click `Catalog -> Installed Operators`.
+   2. Click `Kubefed Operator`.
+   3. Under `Provided APIs`, find `KubeFedWebHook`, and click `Create New`.
+   4. The defaults should be fine here.
+   5. Click `Create`
+5. Create a KubeFed resource to instantiate the KubeFed controller.
    1. On the left panel click `Catalog -> Installed Operators`.
    2. Click `Kubefed Operator`.
    3. Under `Provided APIs`, find `KubeFed`, and click `Create New`.

--- a/docs/ocp4-namespace-scoped.md
+++ b/docs/ocp4-namespace-scoped.md
@@ -159,7 +159,13 @@ you will install the operator to watch all namespaces, the default mode.
    2. Click `Operator Subscriptions` tab.
    3. Ensure the `Status` is "Up to date" for the `kubefed-operator` subscription.
    4. Note the namespace the operator has installed into is openshift-operators
-5. Create a KubeFed resource to instantiate the KubeFed controller.
+5. Create a KubeFedWebHook resource.
+   1. On the left panel click `Catalog -> Installed Operators`.
+   2. Select `test-namespace` from the drop down list for Project
+   3. Click `Kubefed Operator`.
+   4. Under `Provided APIs`, find `KubeFedWebHook`, and click `Create New`.
+   5. The default values should be fine. Click `Create`.
+6. Create a KubeFed resource to instantiate the KubeFed controller.
    1. On the left panel click `Catalog -> Installed Operators`.
    2. Select `test-namespace` from the drop down list for Project
    3. Click `Kubefed Operator`.

--- a/federated-mongodb/README.md
+++ b/federated-mongodb/README.md
@@ -78,6 +78,12 @@ From the command line run the following command:
 cat <<-EOF | oc apply -n federated-mongo -f -
 ---
 apiVersion: operator.kubefed.io/v1alpha1
+kind: KubeFedWebHook
+metadata:
+  name: kubefed-webhook-resource
+spec: 
+---
+apiVersion: operator.kubefed.io/v1alpha1
 kind: KubeFed
 metadata:
   name: kubefed-resource

--- a/federated-pacman/README.md
+++ b/federated-pacman/README.md
@@ -85,6 +85,12 @@ From the command line run the following command:
 cat <<-EOF | oc apply -n kube-federation-system -f -
 ---
 apiVersion: operator.kubefed.io/v1alpha1
+kind: KubeFedWebHook
+metadata:
+  name: kubefed-webhook-resource
+spec: 
+---
+apiVersion: operator.kubefed.io/v1alpha1
 kind: KubeFed
 metadata:
   name: kubefed-resource


### PR DESCRIPTION
Release candidate six now requires two CRs be created to successfully deploy KubeFed on a cluster with the addition of a KubeFedWebHook resource to the existing KubeFed resource.

This PR adds mention and steps to the simple namespaced, cluster scoped, pacman, and mongo demos.

TODO: Determine whether this should be added to the automated demo, or is the demo pinned to a version of the operator which does not require the WebHook CR.